### PR TITLE
Fix PTX b32 pointer type inference

### DIFF
--- a/compiler/ptx/src/lower_to_metal.cpp
+++ b/compiler/ptx/src/lower_to_metal.cpp
@@ -1946,6 +1946,119 @@ std::string emit_metal_source_generic(const std::string& entry_name,
     }
 
     // ── Determine element type for each pointer param ─────────────────────────
+    //
+    // Optimized Clang PTX commonly uses bit types for ordinary C/C++ values:
+    //
+    //   ld.global.b32 %r6, [%rd3];
+    //   ld.global.b32 %r7, [%rd2];
+    //   add.s32       %r8, %r7, %r6;
+    //   st.global.b32 [%rd1], %r8;
+    //
+    // The `.b32` memory opcode does not say whether the pointee is float or int.
+    // Defaulting it to float silently reinterprets `int*` buffers and turns small
+    // integers into denormal floats. Infer the semantic register type from typed
+    // consumers/producers instead. Keep `.b32` genuinely ambiguous when no typed
+    // dataflow evidence exists; the generic emitter must not guess.
+    std::unordered_map<std::string, std::string> reg_value_type;
+    std::unordered_set<std::string> ambiguous_reg_value_type;
+
+    auto record_reg_value_type = [&](const std::string& operand,
+                                     const std::string& type) {
+        const std::string r = get_reg(operand);
+        if (r.empty() || type.empty() || ambiguous_reg_value_type.count(r)) {
+            return;
+        }
+        const auto it = reg_value_type.find(r);
+        if (it == reg_value_type.end()) {
+            reg_value_type[r] = type;
+        } else if (it->second != type) {
+            reg_value_type.erase(it);
+            ambiguous_reg_value_type.insert(r);
+        }
+    };
+
+    auto metal_value_type = [](std::string_view token) -> std::string {
+        if (token == "f64") return "double";
+        if (token == "f32") return "float";
+        if (token == "s64") return "long";
+        if (token == "u64") return "ulong";
+        if (token == "s32") return "int";
+        if (token == "u32") return "uint";
+        if (token == "s16") return "short";
+        if (token == "u16") return "ushort";
+        if (token == "s8") return "char";
+        if (token == "u8") return "uchar";
+        return {};
+    };
+
+    auto opcode_type_tokens = [](const std::string& opcode) {
+        std::vector<std::string> tokens;
+        std::size_t pos = 0;
+        while (pos < opcode.size()) {
+            const std::size_t dot = opcode.find('.', pos);
+            const std::string token =
+                opcode.substr(pos, dot == std::string::npos ? std::string::npos : dot - pos);
+            if (!token.empty()) {
+                const char first = token.front();
+                if ((first == 'f' || first == 's' || first == 'u' || first == 'b') &&
+                    token.size() > 1 &&
+                    std::isdigit(static_cast<unsigned char>(token[1]))) {
+                    tokens.push_back(token);
+                }
+            }
+            if (dot == std::string::npos) break;
+            pos = dot + 1;
+        }
+        return tokens;
+    };
+
+    for (const auto& instr : entry->instructions) {
+        const auto& op = instr.opcode;
+        const auto& ops = instr.operands;
+        if (ops.empty()) continue;
+
+        const std::vector<std::string> type_tokens = opcode_type_tokens(op);
+        if (op.find("cvt") == 0 && type_tokens.size() >= 2 && ops.size() >= 2) {
+            record_reg_value_type(ops[0],
+                                  metal_value_type(type_tokens[type_tokens.size() - 2]));
+            record_reg_value_type(ops[1],
+                                  metal_value_type(type_tokens[type_tokens.size() - 1]));
+            continue;
+        }
+
+        if (type_tokens.empty()) continue;
+        const std::string type = metal_value_type(type_tokens.back());
+        if (type.empty()) continue;  // .b32/.b64 carry no semantic type evidence.
+
+        std::size_t first_value = 0;
+        if (op.find("setp") == 0 || op.find("st.") == 0 ||
+            op.find("atom.") == 0) {
+            first_value = 1;
+        }
+        for (std::size_t i = first_value; i < ops.size(); ++i) {
+            record_reg_value_type(ops[i], type);
+        }
+    }
+
+    // Propagate semantic type through untyped bit moves. Two passes cover the
+    // short move chains emitted by Clang without pretending to solve arbitrary
+    // PTX dataflow here.
+    for (int pass = 0; pass < 2; ++pass) {
+        for (const auto& instr : entry->instructions) {
+            if (instr.opcode.find("mov.b32") != 0 || instr.operands.size() != 2) {
+                continue;
+            }
+            const std::string dest = get_reg(instr.operands[0]);
+            const std::string src = get_reg(instr.operands[1]);
+            if (dest.empty() || src.empty()) continue;
+            if (reg_value_type.count(src)) {
+                record_reg_value_type(dest, reg_value_type.at(src));
+            }
+            if (reg_value_type.count(dest)) {
+                record_reg_value_type(src, reg_value_type.at(dest));
+            }
+        }
+    }
 
     std::unordered_map<std::string, std::string> param_etype;
     for (std::size_t instr_index = 0; instr_index < entry->instructions.size(); ++instr_index) {
@@ -1977,6 +2090,14 @@ std::string emit_metal_source_generic(const std::string& entry_name,
             etype = "int";
         } else if (op.find(".u64") != std::string::npos) {
             etype = "ulong";
+        } else if (op.find(".b32") != std::string::npos) {
+            const std::string value_reg =
+                get_reg(is_load ? instr.operands[0] : instr.operands[1]);
+            const auto value_type = reg_value_type.find(value_reg);
+            if (value_type == reg_value_type.end()) {
+                return {};
+            }
+            etype = value_type->second;
         } else {
             etype = "float";
         }

--- a/tests/unit/ptx_lower_to_metal_test.cpp
+++ b/tests/unit/ptx_lower_to_metal_test.cpp
@@ -986,6 +986,108 @@ DONE:
         }
     }
 
+    // Clang emits ordinary C `int*` loads/stores as untyped `.b32` memory
+    // operations. The typed arithmetic consuming/producing those registers is
+    // the pointee-type evidence. Defaulting `.b32` to float caused issue #5:
+    // a correctly dispatched 2-block integer vector add returned all zeros.
+    const std::string int_b32_ptx = R"PTX(
+.version 7.0
+.target sm_80
+.address_size 64
+.visible .entry add_int_b32(
+    .param .u64 .ptr .align 1 a,
+    .param .u64 .ptr .align 1 b,
+    .param .u64 .ptr .align 1 c,
+    .param .u32 n
+) {
+    .reg .pred %p<2>;
+    .reg .b32 %r<9>;
+    .reg .b64 %rd<11>;
+    ld.param.b64 %rd4, [a];
+    ld.param.b64 %rd5, [c];
+    cvta.to.global.u64 %rd6, %rd5;
+    ld.param.b64 %rd7, [b];
+    cvta.to.global.u64 %rd8, %rd7;
+    cvta.to.global.u64 %rd9, %rd4;
+    ld.param.b32 %r1, [n];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.s32 %p1, %r5, %r1;
+    @%p1 bra DONE;
+    mul.wide.s32 %rd10, %r5, 4;
+    add.s64 %rd1, %rd6, %rd10;
+    add.s64 %rd2, %rd8, %rd10;
+    add.s64 %rd3, %rd9, %rd10;
+    ld.global.b32 %r6, [%rd3];
+    ld.global.b32 %r7, [%rd2];
+    add.s32 %r8, %r7, %r6;
+    st.global.b32 [%rd1], %r8;
+DONE:
+    ret;
+}
+)PTX";
+    cumetal::ptx::LowerToMetalOptions int_b32_options;
+    int_b32_options.entry_name = "add_int_b32";
+    const auto int_b32 =
+        cumetal::ptx::lower_ptx_to_metal_source(int_b32_ptx, int_b32_options);
+    if (!expect(int_b32.ok && int_b32.matched,
+                "integer .b32 vector add lowers through the generic emitter"))
+        return 1;
+    if (!expect(contains(int_b32.metal_source, "device int* a") &&
+                    contains(int_b32.metal_source, "device int* b") &&
+                    contains(int_b32.metal_source, "device int* c"),
+                "typed s32 dataflow maps .b32 pointer parameters to int"))
+        return 1;
+    if (!expect(contains(int_b32.metal_source, "int vr6 = a[gid]") &&
+                    contains(int_b32.metal_source, "int vr7 = b[gid]") &&
+                    contains(int_b32.metal_source, "int vr8 = vr7 + vr6"),
+                "integer .b32 loads and arithmetic remain integer"))
+        return 1;
+
+    // Negative guard: `.b32` itself must not be treated as integer. Optimized
+    // PTX also carries floats in `%r` bit registers, and typed f32 consumers
+    // must keep those pointer parameters floating-point.
+    std::string float_b32_ptx = int_b32_ptx;
+    const auto replace_all = [](std::string* text,
+                                const std::string& from,
+                                const std::string& to) {
+        std::size_t pos = 0;
+        while ((pos = text->find(from, pos)) != std::string::npos) {
+            text->replace(pos, from.size(), to);
+            pos += to.size();
+        }
+    };
+    replace_all(&float_b32_ptx, "add_int_b32", "add_float_b32");
+    replace_all(&float_b32_ptx, "add.s32 %r8", "add.f32 %r8");
+    cumetal::ptx::LowerToMetalOptions float_b32_options;
+    float_b32_options.entry_name = "add_float_b32";
+    const auto float_b32 =
+        cumetal::ptx::lower_ptx_to_metal_source(float_b32_ptx, float_b32_options);
+    if (!expect(float_b32.ok && float_b32.matched,
+                "floating-point .b32 vector add lowers through the generic emitter"))
+        return 1;
+    if (!expect(contains(float_b32.metal_source, "device float* a") &&
+                    contains(float_b32.metal_source, "device float* b") &&
+                    contains(float_b32.metal_source, "device float* c"),
+                "typed f32 dataflow maps .b32 pointer parameters to float"))
+        return 1;
+
+    // With no typed consumer or producer, `.b32` is genuinely ambiguous.
+    // Refuse generic MSL synthesis instead of silently guessing a pointee type.
+    std::string ambiguous_b32_ptx = int_b32_ptx;
+    replace_all(&ambiguous_b32_ptx, "add_int_b32", "copy_ambiguous_b32");
+    replace_all(&ambiguous_b32_ptx, "ld.global.b32 %r7, [%rd2];\n    add.s32 %r8, %r7, %r6;",
+                "mov.b32 %r8, %r6;");
+    cumetal::ptx::LowerToMetalOptions ambiguous_b32_options;
+    ambiguous_b32_options.entry_name = "copy_ambiguous_b32";
+    const auto ambiguous_b32 = cumetal::ptx::lower_ptx_to_metal_source(
+        ambiguous_b32_ptx, ambiguous_b32_options);
+    if (!expect(ambiguous_b32.ok && !ambiguous_b32.matched,
+                "untyped .b32 memory dataflow falls back instead of guessing"))
+        return 1;
+
     std::printf("PASS: ptx lower-to-metal unit tests\n");
     return 0;
 }


### PR DESCRIPTION
## What changed

- infer semantic pointee types for untyped PTX `.b32` global loads and stores from typed register consumers and producers
- propagate inferred types through short `mov.b32` chains
- fall back instead of guessing when `.b32` dataflow remains ambiguous
- add regression coverage for signed integer, floating-point, and ambiguous `.b32` cases

## Why

Clang emits ordinary CUDA `int*` memory accesses as `ld.global.b32` and
`st.global.b32`. The generic PTX-to-MSL emitter defaulted these untyped accesses
to `float`, so integer input bit patterns were read as denormal floats and the
multi-block vector-add example from issue #5 produced all zeros despite a
successful Metal dispatch.

## Impact

Integer CUDA kernels using Clang's `.b32` PTX representation now retain integer
buffer types and arithmetic. Existing floating-point `.b32` dataflow remains
floating-point, while ambiguous cases take the safer fallback path.

## Validation

- exact issue #5 `add<<<2, 4>>>` reproducer: `11 22 33 44 55 66 77 88`
- focused compiler and GPU tests: 8/8 passed
- binary-shim-off focused tests: 4/4 passed
- full suite: 215/216 passed; the remaining pre-existing `PATH` quoting failure
  passed when rerun with a sanitized `PATH`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of untyped `.b32` values during PTX-to-Metal translation.
  * Prevented integer and boolean-like values from being incorrectly interpreted as floating-point values.
  * Added safer fallback behavior when value types cannot be determined reliably.

* **Tests**
  * Added coverage for integer, floating-point, and ambiguous `.b32` pointer and value scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->