### PR TITLE
Make CuMetal installation boring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to CuMetal are documented here. Format follows
 
 ## [Unreleased]
 
-Nothing is released yet. `project(cumetal VERSION 1.0.0)` names the version under development,
-not a shipped one; there is no `v1.0.0` tag. The entries below accumulate toward a first release.
+## [0.1.0] - 2026-07-30
 
 CuMetal compiles CUDA source to Metal and runs it on Apple Silicon GPUs, with a CUDA-compatible
 runtime backed by Metal and Apple's acceleration frameworks. Read [What works](#what-works)
@@ -16,6 +15,14 @@ programs.
 
 ### Added
 
+- **Homebrew tap packaging and an installed `cumetal` front door.** The
+  `Lulzx/homebrew-tap` formula builds the source-first Release configuration with Homebrew LLVM
+  and verifies it by compiling and running a CUDA kernel. `cumetal doctor` checks the complete
+  local toolchain; `cumetal run` scopes runtime lookup to one child process without requiring
+  global `DYLD_*` exports.
+- **An installed-prefix end-to-end gate.** A fresh manifest-backed install must locate all of its
+  headers, libraries, and Clang shims, pass `cumetal doctor`, compile the unmodified `vectorAdd`
+  source, and execute it on the Apple GPU without caller environment setup.
 - **`cumetalc foo.cu -o foo` builds a runnable executable.** An ordinary CUDA file — host code,
   `__global__` kernels, `<<<>>>` launches — compiles and runs with no host/device split and no
   `.metallib` path at runtime. Clang compiles the whole translation unit; device code travels as
@@ -43,6 +50,9 @@ programs.
 
 ### Changed
 
+- **The installer no longer edits shell startup files by default.** `--shell-config` is an
+  explicit opt-in, and even that only adds the installation's `bin` directory to `PATH`. Installs
+  now retain CMake's exact manifest so uninstall covers every tool, header, library, and shim.
 - **Name-selected llm.c/GGML workload bodies are opt-in.** Generic PTX lowering still runs first;
   if it declines, the specialized table is consulted only with
   `CUMETAL_ENABLE_WORKLOAD_SPECIALIZATIONS=1`. The strict llm.c, llama.cpp, and GGML conformance
@@ -64,6 +74,9 @@ programs.
 
 ### Fixed
 
+- **`cumetalc` now quotes the complete temporary `PATH` assignment.** A normal desktop `PATH`
+  containing a directory with spaces previously prevented Clang from starting, breaking the
+  supposedly simple compile command before source compilation began.
 - **The JIT cache key now identifies the compiler build that produced each entry.** It was
   (hand-maintained schema string + policy + PTX + kernel name), which describes nothing about how
   a given build lowers PTX — so changing an MSL template, an instruction handler, or a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(cumetal VERSION 1.0.0 LANGUAGES C CXX OBJCXX)
+project(cumetal VERSION 0.1.0 LANGUAGES C CXX OBJCXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -420,6 +420,23 @@ target_compile_definitions(cumetalc
         CUMETAL_VERSION_STRING="${PROJECT_VERSION}"
 )
 
+add_executable(cumetal
+    tools/cumetal/main.cpp
+)
+
+target_compile_options(cumetal
+    PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+)
+
+target_compile_definitions(cumetal
+    PRIVATE
+        CUMETAL_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+        CUMETAL_VERSION_STRING="${PROJECT_VERSION}"
+)
+
 add_executable(cumetal-ptx2llvm
     compiler/ptx/src/main.cpp
 )
@@ -554,6 +571,7 @@ install(TARGETS
     air_inspect
     air_validate
     cumetal-air-emitter
+    cumetal
     cumetalc
     cumetal-ptx2llvm
     ptx_diff

--- a/README.md
+++ b/README.md
@@ -10,7 +10,31 @@ This is experimental software. The covered paths execute real kernels and check
 real answers. Unsupported paths are expected to fail explicitly. That is a
 better failure mode than silently computing nonsense.
 
-## Start here
+## Install
+
+CuMetal requires macOS 14 or newer on Apple Silicon. Install the source-first
+compiler and runtime from the official CuMetal tap:
+
+```bash
+brew install lulzx/tap/cumetal
+cumetalc vectorAdd.cu -o vectorAdd
+./vectorAdd
+```
+
+Verify the complete local toolchain with:
+
+```bash
+cumetal doctor
+```
+
+Homebrew installs CMake and LLVM as dependencies. Apple's Metal compiler still
+comes from Xcode; if `xcrun --find metal` fails, install Xcode and its Metal
+Toolchain component.
+
+The formula deliberately installs the source-first compiler/runtime without
+the optional `libcuda.dylib` binary shim.
+
+## Build from source
 
 You need:
 
@@ -44,20 +68,42 @@ Runtime-compiled MSL preserves Metal's fast-math default. Set
 GPU provenance reports the selected `math_mode`. Precompiled metallibs retain
 the policy used when they were built.
 
-Install it:
+Install it without changing shell startup files:
 
 ```bash
-cmake --install build --prefix /opt/cumetal
+bash install/install.sh build /opt/cumetal
+/opt/cumetal/bin/cumetal doctor
 ```
 
-The installer scripts use the same prefix by default:
+To also add CuMetal to your shell's `PATH`, opt in explicitly:
 
 ```bash
-bash install/install.sh
-bash install/uninstall.sh
+bash install/install.sh build /opt/cumetal --shell-config
 ```
 
-`install.sh` also adds the prefix to your shell environment.
+Remove the installation with `/opt/cumetal/uninstall.sh`. The uninstaller uses
+the recorded CMake install manifest, so every installed header, tool, shim, and
+library is covered.
+
+## Run
+
+Source-built programs need no launcher:
+
+```bash
+cumetalc samples/vectorAdd/vectorAdd.cu -o vectorAdd
+./vectorAdd
+```
+
+`cumetal run` is a convenience for launching a process with this installation's
+runtime library path scoped to that child:
+
+```bash
+cumetal run ./cuda-application
+```
+
+It does not make unsupported binaries portable. Prebuilt CUDA applications
+still require a compatible PTX payload and an installation configured with
+`CUMETAL_ENABLE_BINARY_SHIM=ON`; SASS-only applications remain unsupported.
 
 ## The model
 
@@ -308,6 +354,7 @@ mistakes have happened before.
 | Tool | Job |
 | --- | --- |
 | `cumetalc` | Compile `.cu`, PTX, or NVVM IR to inspectable stages, `.metallib`, or an executable |
+| `cumetal` | Check an installation with `doctor` or launch a child process with `run` |
 | `air_inspect` | Inspect kernels, bitcode offsets, and metadata in a `.metallib` |
 | `air_validate` | Validate `.metallib` structure and optionally check it with `xcrun` |
 | `cumetal-air-emitter` | AIR research and regression container generation |

--- a/compiler/cumetalc/main.cpp
+++ b/compiler/cumetalc/main.cpp
@@ -438,10 +438,10 @@ int run_executable_driver(const ExecutableDriverOptions& options, const char* ar
     // Clang execs the shims as subprocesses, so they must be found via PATH. Prepend rather than
     // replace so a user-provided toolchain earlier in PATH still loses to ours deliberately.
     const char* existing_path = std::getenv("PATH");
-    const std::string path_prefix =
-        "PATH=" + quote_shell(layout.toolchain_dir.string()) + ":" +
-        (existing_path != nullptr ? std::string(existing_path) : std::string("/usr/bin:/bin")) +
-        " ";
+    const std::string combined_path =
+        layout.toolchain_dir.string() + ":" +
+        (existing_path != nullptr ? std::string(existing_path) : std::string("/usr/bin:/bin"));
+    const std::string path_prefix = "PATH=" + quote_shell(combined_path) + " ";
 
     std::string compile = path_prefix + quote_shell(compiler.string()) +
                           " -x cuda -std=c++17 -O2"

--- a/docs/build.md
+++ b/docs/build.md
@@ -7,8 +7,33 @@ Build
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 cmake --install build --prefix /tmp/cumetal-install
+/tmp/cumetal-install/bin/cumetal doctor
 # optional: also install the libcuda.dylib drop-in alias (see docs/legal-notice.md)
 cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCUMETAL_ENABLE_BINARY_SHIM=ON
+```
+
+For a manifest-backed install with a matching uninstaller:
+
+```bash
+bash install/install.sh build /opt/cumetal
+# Optional and explicit; the default does not edit shell startup files.
+bash install/install.sh build /opt/cumetal --shell-config
+```
+
+The installer does not export global `DYLD_*` variables. Linked output from
+`cumetalc` has an rpath to its installed runtime, and `cumetal run` scopes
+runtime lookup changes to the process it launches.
+
+Homebrew packaging
+------------------
+
+The formula is maintained in
+[`Lulzx/homebrew-tap`](https://github.com/Lulzx/homebrew-tap). It builds a
+Release configuration, depends on Homebrew LLVM, keeps the binary shim off, and
+runs a compile-and-execute GPU smoke test in `brew test cumetal`:
+
+```bash
+brew install lulzx/tap/cumetal
 ```
 
 Two independent switches
@@ -33,6 +58,9 @@ CUMETAL_TRACE_GPU=1 /tmp/vectorAdd
 
 An installed `cumetalc` finds its headers, `libcumetal.dylib`, and the `ptxas`/`fatbinary` shims
 relative to its own path. Set `CUMETAL_ROOT` to point it at a prefix explicitly.
+
+Use `cumetal doctor` to check Apple Silicon, macOS, LLVM, Metal tools, headers,
+and runtime discovery in one pass.
 
 Generate and validate a reference metallib (requires full Xcode)
 -----------------------------------------------------------------

--- a/docs/known-gaps.md
+++ b/docs/known-gaps.md
@@ -226,6 +226,11 @@ as gaps have been closed.
   lowering previously fell through to a bare `ret void` body, producing a kernel that loaded,
   launched, and wrote nothing — the caller read back whatever was already in the output buffer
   with no diagnostic. Both strict and tolerant modes now return an error.
+- **`cumetal run` is an environment-scoped launcher, not a universal binary translator.** It
+  prepends the selected installation's library directory only for the child process. Programs
+  built by `cumetalc` already run directly and do not need it. Prebuilt applications require
+  `CUMETAL_ENABLE_BINARY_SHIM=ON`, a load command that dyld can resolve through the shim, and
+  embedded supported PTX. Absolute NVIDIA library paths and SASS-only binaries are not repaired.
 - **`cumetalc foo.cu -o foo` produces a complete linked executable** (spec §11 Phase 2/3 exit
   criterion), covered by `functional_cumetalc_link_executable`. An unmodified CUDA source file
   using `<<<>>>` compiles and runs with no host/device split and no metallib path at runtime.

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,22 +3,15 @@ set -euo pipefail
 
 BUILD_DIR="${1:-build}"
 PREFIX="${2:-/opt/cumetal}"
+SHELL_CONFIG="${3:-}"
 
 MARKER_BEGIN="# >>> cumetal >>>"
 MARKER_END="# <<< cumetal <<<"
 
-# Detect shell and pick the right config file + syntax.
-# CUMETAL_SHELL_RC overrides auto-detection.
-if [[ -n "${CUMETAL_SHELL_RC:-}" ]]; then
-  SHELL_RC="$CUMETAL_SHELL_RC"
-  IS_FISH=0
-  if [[ "$SHELL_RC" == *config.fish ]]; then IS_FISH=1; fi
-elif [[ "${SHELL:-}" == */fish ]]; then
-  SHELL_RC="${HOME}/.config/fish/config.fish"
-  IS_FISH=1
-else
-  SHELL_RC="${HOME}/.zshrc"
-  IS_FISH=0
+if [[ -n "$SHELL_CONFIG" && "$SHELL_CONFIG" != "--shell-config" ]]; then
+  echo "unknown option: $SHELL_CONFIG" >&2
+  echo "usage: $0 [build-dir] [prefix] [--shell-config]" >&2
+  exit 2
 fi
 
 if [[ ! -d "$BUILD_DIR" ]]; then
@@ -26,38 +19,68 @@ if [[ ! -d "$BUILD_DIR" ]]; then
   exit 1
 fi
 
+if [[ -z "$PREFIX" || "$PREFIX" == "/" ]]; then
+  echo "refusing to install into an empty prefix or filesystem root" >&2
+  exit 2
+fi
+mkdir -p "$PREFIX"
+PREFIX="$(cd "$PREFIX" && pwd -P)"
+
 cmake --install "$BUILD_DIR" --prefix "$PREFIX"
 
 install -m 755 "$(dirname "$0")/uninstall.sh" "$PREFIX/uninstall.sh"
-
-mkdir -p "$(dirname "$SHELL_RC")"
-touch "$SHELL_RC"
-
-if grep -qF "$MARKER_BEGIN" "$SHELL_RC"; then
-  tmp="$(mktemp)"
-  awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
-    $0 == begin {skip=1; next}
-    $0 == end {skip=0; next}
-    skip != 1 {print}
-  ' "$SHELL_RC" > "$tmp"
-  mv "$tmp" "$SHELL_RC"
+mkdir -p "$PREFIX/share/cumetal"
+if [[ -f "$BUILD_DIR/install_manifest.txt" ]]; then
+  install -m 644 "$BUILD_DIR/install_manifest.txt" "$PREFIX/share/cumetal/install_manifest.txt"
 fi
 
-if [[ "$IS_FISH" -eq 1 ]]; then
-  cat >> "$SHELL_RC" <<EOF
+if [[ "$SHELL_CONFIG" == "--shell-config" || -n "${CUMETAL_SHELL_RC:-}" ]]; then
+  # Shell startup files are changed only by explicit request. CUMETAL_SHELL_RC
+  # both opts in and selects a file, which keeps automated installs isolated.
+  if [[ -n "${CUMETAL_SHELL_RC:-}" ]]; then
+    SHELL_RC="$CUMETAL_SHELL_RC"
+    IS_FISH=0
+    if [[ "$SHELL_RC" == *config.fish ]]; then IS_FISH=1; fi
+  elif [[ "${SHELL:-}" == */fish ]]; then
+    SHELL_RC="${HOME}/.config/fish/config.fish"
+    IS_FISH=1
+  else
+    SHELL_RC="${HOME}/.zshrc"
+    IS_FISH=0
+  fi
+
+  mkdir -p "$(dirname "$SHELL_RC")"
+  touch "$SHELL_RC"
+
+  if grep -qF "$MARKER_BEGIN" "$SHELL_RC"; then
+    tmp="$(mktemp)"
+    awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+      $0 == begin {skip=1; next}
+      $0 == end {skip=0; next}
+      skip != 1 {print}
+    ' "$SHELL_RC" > "$tmp"
+    mv "$tmp" "$SHELL_RC"
+  fi
+
+  if [[ "$IS_FISH" -eq 1 ]]; then
+    cat >> "$SHELL_RC" <<EOF
 $MARKER_BEGIN
 set -gx PATH "$PREFIX/bin" \$PATH
-set -gx DYLD_FALLBACK_LIBRARY_PATH "$PREFIX/lib" \$DYLD_FALLBACK_LIBRARY_PATH
 $MARKER_END
 EOF
-else
-  cat >> "$SHELL_RC" <<EOF
+  else
+    cat >> "$SHELL_RC" <<EOF
 $MARKER_BEGIN
 export PATH="$PREFIX/bin:\$PATH"
-export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib:\${DYLD_FALLBACK_LIBRARY_PATH:-}"
 $MARKER_END
 EOF
+  fi
+
+  echo "Updated $SHELL_RC with CuMetal's bin directory"
 fi
 
 echo "Installed CuMetal to $PREFIX"
-echo "Updated $SHELL_RC with CuMetal environment settings"
+echo "Run $PREFIX/bin/cumetal doctor to verify the installation"
+if [[ "$SHELL_CONFIG" != "--shell-config" && -z "${CUMETAL_SHELL_RC:-}" ]]; then
+  echo "Add $PREFIX/bin to PATH, or rerun with --shell-config to do that automatically"
+fi

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -6,6 +6,12 @@ PREFIX="${1:-/opt/cumetal}"
 MARKER_BEGIN="# >>> cumetal >>>"
 MARKER_END="# <<< cumetal <<<"
 
+if [[ -z "$PREFIX" || "$PREFIX" == "/" || ! -d "$PREFIX" ]]; then
+  echo "refusing to uninstall from an empty, missing, or filesystem-root prefix" >&2
+  exit 2
+fi
+PREFIX="$(cd "$PREFIX" && pwd -P)"
+
 # Mirror the shell detection logic from install.sh.
 if [[ -n "${CUMETAL_SHELL_RC:-}" ]]; then
   SHELL_RC="$CUMETAL_SHELL_RC"
@@ -15,23 +21,52 @@ else
   SHELL_RC="${HOME}/.zshrc"
 fi
 
-rm -f "$PREFIX/bin/air_inspect"
-rm -f "$PREFIX/bin/air_validate"
-rm -f "$PREFIX/bin/cumetal-air-emitter"
-rm -f "$PREFIX/bin/cumetalc"
-rm -f "$PREFIX/lib/libcumetal.dylib"
-rm -f "$PREFIX/lib/libcublas.dylib"
-rm -f "$PREFIX/lib/libcufft.dylib"
-rm -f "$PREFIX/lib/libcurand.dylib"
-rm -f "$PREFIX/include/cuda.h"
-rm -f "$PREFIX/include/cuda_fp16.h"
-rm -f "$PREFIX/include/cuda_runtime.h"
-rm -f "$PREFIX/include/cufft.h"
-rm -f "$PREFIX/include/cublas_v2.h"
-rm -f "$PREFIX/include/curand.h"
-rm -f "$PREFIX/include/cooperative_groups.h"
-rm -f "$PREFIX/include/cooperative_groups/reduce.h"
-rmdir "$PREFIX/include/cooperative_groups" 2>/dev/null || true
+MANIFEST="$PREFIX/share/cumetal/install_manifest.txt"
+if [[ -f "$MANIFEST" ]]; then
+  DIRECTORY_LIST="$(mktemp)"
+  while IFS= read -r installed_file; do
+    [[ -z "$installed_file" ]] && continue
+    case "$installed_file" in
+      "$PREFIX"/*)
+        rm -f "$installed_file"
+        directory="$(dirname "$installed_file")"
+        while [[ "$directory" == "$PREFIX"/* ]]; do
+          printf '%s\n' "$directory" >> "$DIRECTORY_LIST"
+          directory="$(dirname "$directory")"
+        done
+        ;;
+      *)
+        echo "Refusing to remove path outside prefix: $installed_file" >&2
+        rm -f "$DIRECTORY_LIST"
+        exit 1
+        ;;
+    esac
+  done < "$MANIFEST"
+  LC_ALL=C sort -ru "$DIRECTORY_LIST" | while IFS= read -r directory; do
+    rmdir "$directory" 2>/dev/null || true
+  done
+  rm -f "$DIRECTORY_LIST"
+else
+  # Compatibility with installations made before manifests were recorded.
+  rm -f "$PREFIX/bin/air_inspect"
+  rm -f "$PREFIX/bin/air_validate"
+  rm -f "$PREFIX/bin/cumetal-air-emitter"
+  rm -f "$PREFIX/bin/cumetal"
+  rm -f "$PREFIX/bin/cumetalc"
+  rm -f "$PREFIX/lib/libcumetal.dylib"
+  rm -f "$PREFIX/lib/libcublas.dylib"
+  rm -f "$PREFIX/lib/libcufft.dylib"
+  rm -f "$PREFIX/lib/libcurand.dylib"
+  rm -f "$PREFIX/include/cuda.h"
+  rm -f "$PREFIX/include/cuda_fp16.h"
+  rm -f "$PREFIX/include/cuda_runtime.h"
+  rm -f "$PREFIX/include/cufft.h"
+  rm -f "$PREFIX/include/cublas_v2.h"
+  rm -f "$PREFIX/include/curand.h"
+  rm -f "$PREFIX/include/cooperative_groups.h"
+  rm -f "$PREFIX/include/cooperative_groups/reduce.h"
+fi
+rm -f "$MANIFEST"
 rm -f "$PREFIX/uninstall.sh"
 
 if [[ -f "$SHELL_RC" ]] && grep -qF "$MARKER_BEGIN" "$SHELL_RC"; then
@@ -44,10 +79,18 @@ if [[ -f "$SHELL_RC" ]] && grep -qF "$MARKER_BEGIN" "$SHELL_RC"; then
   mv "$tmp" "$SHELL_RC"
 fi
 
+rmdir "$PREFIX/libexec/cumetal/cuda_toolchain" 2>/dev/null || true
+rmdir "$PREFIX/libexec/cumetal" 2>/dev/null || true
+rmdir "$PREFIX/libexec" 2>/dev/null || true
+rmdir "$PREFIX/share/cumetal" 2>/dev/null || true
+rmdir "$PREFIX/share" 2>/dev/null || true
 rmdir "$PREFIX/bin" 2>/dev/null || true
 rmdir "$PREFIX/lib" 2>/dev/null || true
+rmdir "$PREFIX/include/cooperative_groups" 2>/dev/null || true
 rmdir "$PREFIX/include" 2>/dev/null || true
 rmdir "$PREFIX" 2>/dev/null || true
 
 echo "Removed CuMetal from $PREFIX"
-echo "Removed CuMetal environment settings from $SHELL_RC"
+if [[ -f "$SHELL_RC" ]]; then
+  echo "Removed CuMetal environment settings from $SHELL_RC"
+fi

--- a/runtime/api/cumetal_native.h
+++ b/runtime/api/cumetal_native.h
@@ -15,10 +15,10 @@ extern "C" {
  * These must stay in step with project(cumetal VERSION ...) in CMakeLists.txt. They are
  * duplicated rather than generated so this header stays usable standalone; unit_version_matches
  * fails the build's test suite if the two ever drift. */
-#define CUMETAL_VERSION_MAJOR 1
-#define CUMETAL_VERSION_MINOR 0
+#define CUMETAL_VERSION_MAJOR 0
+#define CUMETAL_VERSION_MINOR 1
 #define CUMETAL_VERSION_PATCH 0
-#define CUMETAL_VERSION_STRING "1.0.0"
+#define CUMETAL_VERSION_STRING "0.1.0"
 
 /* Encoded as major*10000 + minor*100 + patch, so versions compare with < and >. */
 #define CUMETAL_VERSION \

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -2877,4 +2877,20 @@ if(CUMETAL_ENABLE_CUDA_REGISTRATION)
                 ${CMAKE_CURRENT_BINARY_DIR}/cumetalc_link_executable
     )
     set_tests_properties(functional_cumetalc_link_executable PROPERTIES SKIP_RETURN_CODE 77)
+
+    add_test(
+        NAME functional_installed_cumetalc_link_executable
+        COMMAND bash
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_installed_cumetalc_link_executable.sh
+                ${CMAKE_SOURCE_DIR}/install/install.sh
+                ${CMAKE_BINARY_DIR}
+                ${CMAKE_SOURCE_DIR}/samples/vectorAdd/vectorAdd.cu
+                ${CMAKE_CURRENT_SOURCE_DIR}/run_cumetalc_link_executable.sh
+    )
+    set_tests_properties(
+        functional_installed_cumetalc_link_executable
+        PROPERTIES
+            SKIP_RETURN_CODE 77
+            RESOURCE_LOCK cumetal_install_manifest
+    )
 endif()

--- a/tests/functional/run_cumetalc_link_executable.sh
+++ b/tests/functional/run_cumetalc_link_executable.sh
@@ -34,7 +34,13 @@ rm -f "${OUT_BIN}"
 echo "Building ${SOURCE_CU} -> ${OUT_BIN}"
 BUILD_LOG="${WORK_DIR}/link_executable.build.log"
 BUILD_STATUS=0
-"${CUMETALC}" "${SOURCE_CU}" -o "${OUT_BIN}" >"${BUILD_LOG}" 2>&1 || BUILD_STATUS=$?
+# A PATH entry containing spaces used to split cumetalc's shell assignment and
+# prevent Clang from starting. Keep this ordinary desktop configuration in the
+# primary installed-compiler gate.
+PATH_WITH_SPACES="${WORK_DIR}/toolbox scripts"
+mkdir -p "${PATH_WITH_SPACES}"
+PATH="${PATH_WITH_SPACES}:${PATH}" \
+  "${CUMETALC}" "${SOURCE_CU}" -o "${OUT_BIN}" >"${BUILD_LOG}" 2>&1 || BUILD_STATUS=$?
 
 # Homebrew LLVM emits a benign "'+ptxNN' is not a recognized feature" line on toolchains new
 # enough not to need the flag. Filter it from the printed log only, never from the exit status.

--- a/tests/functional/run_installed_cumetalc_link_executable.sh
+++ b/tests/functional/run_installed_cumetalc_link_executable.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_SCRIPT="${1:?usage: run_installed_cumetalc_link_executable.sh <install.sh> <build-dir> <source.cu> <link-test.sh>}"
+BUILD_DIR="${2:?}"
+SOURCE_CU="${3:?}"
+LINK_TEST="${4:?}"
+
+TMP_ROOT="$(mktemp -d)"
+PREFIX="$TMP_ROOT/prefix"
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR"
+
+cleanup() {
+  if [[ -x "$PREFIX/uninstall.sh" ]]; then
+    env -u CUMETAL_SHELL_RC HOME="$HOME_DIR" SHELL=/bin/zsh \
+      bash "$PREFIX/uninstall.sh" "$PREFIX" >/dev/null
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+env -u CUMETAL_SHELL_RC HOME="$HOME_DIR" SHELL=/bin/zsh \
+  bash "$INSTALL_SCRIPT" "$BUILD_DIR" "$PREFIX"
+
+if [[ -e "$HOME_DIR/.zshrc" ]]; then
+  echo "FAIL: default installation modified a shell startup file" >&2
+  exit 1
+fi
+
+"$PREFIX/bin/cumetal" doctor
+bash "$LINK_TEST" \
+  "$PREFIX/bin/cumetalc" \
+  "$SOURCE_CU" \
+  "$TMP_ROOT/compile-and-run"
+
+echo "PASS: a fresh installed prefix compiled and ran unmodified CUDA source"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -474,6 +474,10 @@ add_test(
             ${CMAKE_SOURCE_DIR}/install/uninstall.sh
             ${CMAKE_BINARY_DIR}
 )
+set_tests_properties(
+    unit_install_uninstall_scripts
+    PROPERTIES RESOURCE_LOCK cumetal_install_manifest
+)
 
 add_test(
     NAME unit_llama_build_contract
@@ -564,4 +568,12 @@ add_test(
             ${PROJECT_VERSION}
             $<TARGET_FILE:cumetalc>
             ${CMAKE_SOURCE_DIR}/runtime/api/cumetal_native.h
+)
+
+add_test(
+    NAME unit_cumetal_cli
+    COMMAND bash
+            ${CMAKE_CURRENT_SOURCE_DIR}/run_cumetal_cli_test.sh
+            $<TARGET_FILE:cumetal>
+            $<TARGET_FILE_DIR:cumetal_runtime>
 )

--- a/tests/unit/run_cumetal_cli_test.sh
+++ b/tests/unit/run_cumetal_cli_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CUMETAL="${1:?usage: run_cumetal_cli_test.sh <cumetal> <runtime-directory>}"
+RUNTIME_DIR="${2:?}"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+"$CUMETAL" version | grep -q '^cumetal '
+"$CUMETAL" --help | grep -q 'cumetalc program.cu -o program'
+
+# macOS strips DYLD_* when launching a platform-protected system binary. Build
+# an ordinary user executable so the test observes the environment that a CUDA
+# application receives.
+cat > "$TMP_ROOT/printenv.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+int main(void) {
+    const char *value = getenv("DYLD_LIBRARY_PATH");
+    if (value == NULL) return 1;
+    puts(value);
+    return 0;
+}
+EOF
+/usr/bin/cc "$TMP_ROOT/printenv.c" -o "$TMP_ROOT/printenv"
+DYLD_PATH="$("$CUMETAL" run "$TMP_ROOT/printenv")"
+case "$DYLD_PATH" in
+  "$RUNTIME_DIR"|"$RUNTIME_DIR":*) ;;
+  *)
+    echo "FAIL: cumetal run did not prepend the runtime directory: $DYLD_PATH" >&2
+    exit 1
+    ;;
+esac
+
+set +e
+"$CUMETAL" run >/dev/null 2>&1
+MISSING_STATUS=$?
+"$CUMETAL" unknown >/dev/null 2>&1
+UNKNOWN_STATUS=$?
+"$CUMETAL" run /path/that/does/not/exist >/dev/null 2>&1
+EXEC_STATUS=$?
+set -e
+
+if [[ "$MISSING_STATUS" -ne 2 ]]; then
+  echo "FAIL: missing run target returned $MISSING_STATUS instead of 2" >&2
+  exit 1
+fi
+if [[ "$UNKNOWN_STATUS" -ne 2 ]]; then
+  echo "FAIL: unknown command returned $UNKNOWN_STATUS instead of 2" >&2
+  exit 1
+fi
+if [[ "$EXEC_STATUS" -ne 127 ]]; then
+  echo "FAIL: missing executable returned $EXEC_STATUS instead of 127" >&2
+  exit 1
+fi
+
+echo "PASS: cumetal CLI reports its version and launches with the installed runtime"

--- a/tests/unit/run_install_uninstall_test.sh
+++ b/tests/unit/run_install_uninstall_test.sh
@@ -6,8 +6,11 @@ UNINSTALL_SCRIPT="$2"
 BUILD_DIR="$3"
 
 TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
 PREFIX="$TMP_ROOT/prefix"
 SHELL_RC="$TMP_ROOT/.zshrc"
+HOME_DIR="$TMP_ROOT/home"
+mkdir -p "$HOME_DIR"
 touch "$SHELL_RC"
 
 cleanup() {
@@ -15,33 +18,60 @@ cleanup() {
 }
 trap cleanup EXIT
 
-CUMETAL_SHELL_RC="$SHELL_RC" bash "$INSTALL_SCRIPT" "$BUILD_DIR" "$PREFIX"
+# Default installation must not mutate shell startup files.
+env -u CUMETAL_SHELL_RC HOME="$HOME_DIR" SHELL=/bin/zsh \
+  bash "$INSTALL_SCRIPT" "$BUILD_DIR" "$PREFIX"
 
 test -x "$PREFIX/bin/air_inspect"
 test -x "$PREFIX/bin/air_validate"
 test -x "$PREFIX/bin/cumetal-air-emitter"
+test -x "$PREFIX/bin/cumetal"
 test -x "$PREFIX/bin/cumetalc"
 test -f "$PREFIX/lib/libcumetal.dylib"
 test -f "$PREFIX/include/cuda.h"
 test -f "$PREFIX/include/cuda_runtime.h"
 test -x "$PREFIX/uninstall.sh"
+test -f "$PREFIX/share/cumetal/install_manifest.txt"
 
-grep -qF "# >>> cumetal >>>" "$SHELL_RC"
-grep -qF "# <<< cumetal <<<" "$SHELL_RC"
-grep -qF "export PATH=\"$PREFIX/bin:\$PATH\"" "$SHELL_RC"
-grep -qF "export DYLD_FALLBACK_LIBRARY_PATH=\"$PREFIX/lib:\${DYLD_FALLBACK_LIBRARY_PATH:-}\"" \
-  "$SHELL_RC"
+test ! -e "$HOME_DIR/.zshrc"
+"$PREFIX/bin/cumetal" version | grep -q "^cumetal "
+"$PREFIX/bin/cumetal" run /usr/bin/true
 
-CUMETAL_SHELL_RC="$SHELL_RC" bash "$PREFIX/uninstall.sh" "$PREFIX"
+env -u CUMETAL_SHELL_RC HOME="$HOME_DIR" SHELL=/bin/zsh \
+  bash "$PREFIX/uninstall.sh" "$PREFIX"
 
 if [[ -e "$PREFIX/bin/air_inspect" || -e "$PREFIX/lib/libcumetal.dylib" ]]; then
   echo "FAIL: expected installed files to be removed" >&2
   exit 1
 fi
 
+# Shell configuration remains available as an explicit opt-in and is reversible.
+CUMETAL_SHELL_RC="$SHELL_RC" bash "$INSTALL_SCRIPT" "$BUILD_DIR" "$PREFIX" --shell-config
+grep -qF "# >>> cumetal >>>" "$SHELL_RC"
+grep -qF "# <<< cumetal <<<" "$SHELL_RC"
+grep -qF "export PATH=\"$PREFIX/bin:\$PATH\"" "$SHELL_RC"
+if grep -qF "DYLD_" "$SHELL_RC"; then
+  echo "FAIL: installer should not add global DYLD variables" >&2
+  exit 1
+fi
+
+CUMETAL_SHELL_RC="$SHELL_RC" bash "$PREFIX/uninstall.sh" "$PREFIX"
 if grep -qF "# >>> cumetal >>>" "$SHELL_RC"; then
   echo "FAIL: expected shell marker to be removed" >&2
   exit 1
 fi
 
-echo "PASS: install/uninstall scripts manage files and shell config markers"
+if bash "$INSTALL_SCRIPT" "$BUILD_DIR" "$PREFIX" --not-an-option >/dev/null 2>&1; then
+  echo "FAIL: installer accepted an unknown option" >&2
+  exit 1
+fi
+if bash "$INSTALL_SCRIPT" "$BUILD_DIR" / >/dev/null 2>&1; then
+  echo "FAIL: installer accepted the filesystem root as its prefix" >&2
+  exit 1
+fi
+if bash "$UNINSTALL_SCRIPT" / >/dev/null 2>&1; then
+  echo "FAIL: uninstaller accepted the filesystem root as its prefix" >&2
+  exit 1
+fi
+
+echo "PASS: install/uninstall scripts are isolated, manifest-backed, and reversible"

--- a/tools/cumetal/main.cpp
+++ b/tools/cumetal/main.cpp
@@ -1,0 +1,266 @@
+#include <mach-o/dyld.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifndef CUMETAL_SOURCE_DIR
+#define CUMETAL_SOURCE_DIR ""
+#endif
+
+#ifndef CUMETAL_VERSION_STRING
+#define CUMETAL_VERSION_STRING "unknown"
+#endif
+
+namespace {
+
+struct CommandResult {
+  int exit_code = 1;
+  std::string output;
+};
+
+CommandResult run_capture(const char *command) {
+  CommandResult result;
+  std::array<char, 512> buffer{};
+  FILE *pipe = popen(command, "r");
+  if (pipe == nullptr)
+    return result;
+  while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) !=
+         nullptr) {
+    result.output.append(buffer.data());
+  }
+  const int status = pclose(pipe);
+  if (WIFEXITED(status))
+    result.exit_code = WEXITSTATUS(status);
+  while (!result.output.empty() &&
+         std::isspace(static_cast<unsigned char>(result.output.back())) != 0) {
+    result.output.pop_back();
+  }
+  return result;
+}
+
+std::filesystem::path executable_path(const char *argv0) {
+  uint32_t size = 0;
+  _NSGetExecutablePath(nullptr, &size);
+  std::vector<char> buffer(size + 1, '\0');
+  std::error_code ec;
+  if (_NSGetExecutablePath(buffer.data(), &size) == 0) {
+    const auto resolved = std::filesystem::weakly_canonical(buffer.data(), ec);
+    if (!ec)
+      return resolved;
+  }
+  if (argv0 != nullptr && argv0[0] != '\0') {
+    const auto resolved = std::filesystem::weakly_canonical(argv0, ec);
+    if (!ec)
+      return resolved;
+  }
+  return {};
+}
+
+struct Layout {
+  std::filesystem::path prefix;
+  std::filesystem::path bin_dir;
+  std::filesystem::path include_dir;
+  std::filesystem::path lib_dir;
+};
+
+Layout resolve_layout(const char *argv0) {
+  if (const char *root = std::getenv("CUMETAL_ROOT");
+      root != nullptr && root[0] != '\0') {
+    const std::filesystem::path prefix(root);
+    return {prefix, prefix / "bin", prefix / "include", prefix / "lib"};
+  }
+
+  const std::filesystem::path self = executable_path(argv0);
+  const std::filesystem::path bin_dir = self.parent_path();
+  const std::filesystem::path prefix = bin_dir.parent_path();
+  if (std::filesystem::exists(prefix / "include" / "cuda_runtime.h") &&
+      std::filesystem::exists(prefix / "lib" / "libcumetal.dylib")) {
+    return {prefix, bin_dir, prefix / "include", prefix / "lib"};
+  }
+
+  return {prefix, bin_dir,
+          std::filesystem::path(CUMETAL_SOURCE_DIR) / "runtime" / "api",
+          bin_dir};
+}
+
+void print_usage(const char *argv0) {
+  const std::string name =
+      std::filesystem::path(argv0 != nullptr ? argv0 : "cumetal")
+          .filename()
+          .string();
+  std::cout << "CuMetal " << CUMETAL_VERSION_STRING << "\n\n"
+            << "Usage:\n"
+            << "  " << name << " doctor\n"
+            << "  " << name << " run <program> [args...]\n"
+            << "  " << name << " version\n\n"
+            << "Compile CUDA source with:\n"
+            << "  cumetalc program.cu -o program\n";
+}
+
+bool report_check(bool ok, std::string_view label, std::string_view detail) {
+  std::cout << (ok ? "[ok]    " : "[error] ") << label;
+  if (!detail.empty())
+    std::cout << ": " << detail;
+  std::cout << '\n';
+  return ok;
+}
+
+int doctor(const char *argv0) {
+  const Layout layout = resolve_layout(argv0);
+  bool ready = true;
+
+  const CommandResult arch = run_capture("/usr/bin/uname -m 2>/dev/null");
+  ready &= report_check(
+      arch.exit_code == 0 && arch.output == "arm64", "Apple Silicon",
+      arch.output.empty() ? "architecture could not be determined"
+                          : arch.output);
+
+  const CommandResult macos =
+      run_capture("/usr/bin/sw_vers -productVersion 2>/dev/null");
+  bool supported_macos = false;
+  if (macos.exit_code == 0 && !macos.output.empty()) {
+    const std::size_t dot = macos.output.find('.');
+    const std::string major = macos.output.substr(0, dot);
+    supported_macos =
+        !major.empty() &&
+        major.find_first_not_of("0123456789") == std::string::npos &&
+        std::stoi(major) >= 14;
+  }
+  ready &= report_check(supported_macos, "macOS 14+", macos.output);
+
+  const bool compiler = std::filesystem::exists(layout.bin_dir / "cumetalc");
+  ready &= report_check(compiler, "CuMetal compiler",
+                        (layout.bin_dir / "cumetalc").string());
+
+  const bool headers =
+      std::filesystem::exists(layout.include_dir / "cuda_runtime.h");
+  ready &= report_check(headers, "CUDA headers", layout.include_dir.string());
+
+  const bool runtime =
+      std::filesystem::exists(layout.lib_dir / "libcumetal.dylib");
+  ready &= report_check(runtime, "CuMetal runtime", layout.lib_dir.string());
+
+  std::filesystem::path clang;
+  if (const char *configured = std::getenv("CUMETAL_CUDA_CLANG");
+      configured != nullptr && configured[0] != '\0') {
+    clang = configured;
+  } else {
+    static constexpr const char *candidates[] = {
+        "/opt/homebrew/opt/llvm/bin/clang++",
+        "/usr/local/opt/llvm/bin/clang++",
+    };
+    for (const char *candidate : candidates) {
+      if (std::filesystem::exists(candidate)) {
+        clang = candidate;
+        break;
+      }
+    }
+    if (clang.empty()) {
+      const CommandResult found = run_capture("command -v clang++ 2>/dev/null");
+      if (found.exit_code == 0)
+        clang = found.output;
+    }
+  }
+  ready &= report_check(
+      !clang.empty() && std::filesystem::exists(clang), "CUDA-capable Clang",
+      clang.empty() ? "install with `brew install llvm`" : clang.string());
+
+  const CommandResult metal = run_capture("xcrun --find metal 2>/dev/null");
+  ready &= report_check(
+      metal.exit_code == 0 && !metal.output.empty(), "Metal compiler",
+      metal.output.empty() ? "install Xcode's Metal toolchain" : metal.output);
+
+  const CommandResult metallib =
+      run_capture("xcrun --find metallib 2>/dev/null");
+  ready &= report_check(
+      metallib.exit_code == 0 && !metallib.output.empty(), "Metal library tool",
+      metallib.output.empty() ? "install Xcode's Metal toolchain"
+                              : metallib.output);
+
+  const bool binary_shim =
+      std::filesystem::exists(layout.lib_dir / "libcuda.dylib");
+  std::cout << "[info]  Binary compatibility shim: "
+            << (binary_shim
+                    ? "installed"
+                    : "not installed (source compilation is unaffected)")
+            << '\n';
+
+  if (ready) {
+    std::cout << "\nCuMetal is ready. Try:\n"
+              << "  cumetalc vectorAdd.cu -o vectorAdd\n"
+              << "  ./vectorAdd\n";
+    return 0;
+  }
+  std::cerr << "\nCuMetal is not ready; fix the [error] checks above.\n";
+  return 1;
+}
+
+std::string prepend_path(const std::filesystem::path &directory,
+                         const char *existing) {
+  if (existing == nullptr || existing[0] == '\0')
+    return directory.string();
+  return directory.string() + ":" + existing;
+}
+
+int run_program(int argc, char **argv) {
+  if (argc < 3) {
+    std::cerr << "cumetal run expects a program path\n";
+    return 2;
+  }
+
+  const Layout layout = resolve_layout(argv[0]);
+  if (!std::filesystem::exists(layout.lib_dir / "libcumetal.dylib")) {
+    std::cerr << "cumetal run failed: libcumetal.dylib was not found under "
+              << layout.lib_dir
+              << "\n"
+                 "Set CUMETAL_ROOT to the CuMetal installation prefix.\n";
+    return 1;
+  }
+
+  const std::string dyld_library =
+      prepend_path(layout.lib_dir, std::getenv("DYLD_LIBRARY_PATH"));
+  const std::string dyld_fallback =
+      prepend_path(layout.lib_dir, std::getenv("DYLD_FALLBACK_LIBRARY_PATH"));
+  setenv("DYLD_LIBRARY_PATH", dyld_library.c_str(), 1);
+  setenv("DYLD_FALLBACK_LIBRARY_PATH", dyld_fallback.c_str(), 1);
+
+  execvp(argv[2], &argv[2]);
+  std::perror("cumetal run failed");
+  return 127;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  const std::string_view command(argv[1]);
+  if (command == "doctor")
+    return doctor(argv[0]);
+  if (command == "run")
+    return run_program(argc, argv);
+  if (command == "version" || command == "--version" || command == "-v") {
+    std::cout << "cumetal " << CUMETAL_VERSION_STRING << '\n';
+    return 0;
+  }
+  if (command == "help" || command == "--help" || command == "-h") {
+    print_usage(argv[0]);
+    return 0;
+  }
+
+  std::cerr << "unknown command: " << command << "\n\n";
+  print_usage(argv[0]);
+  return 2;
+}


### PR DESCRIPTION
## What changed

- adds relocatable Homebrew-ready installation and a manifest-backed uninstaller
- adds `cumetal doctor` and environment-scoped `cumetal run`
- fixes `cumetalc` when the user's `PATH` contains spaces
- adds fresh-installed-prefix compile, Apple-GPU execution, and negative-path tests
- aligns the first experimental release version to `0.1.0`
- documents the dedicated `lulzx/tap/cumetal` distribution path

## Why

The primary source workflow should be a normal install followed by:

```bash
cumetalc vectorAdd.cu -o vectorAdd
./vectorAdd
```

without manual include paths, library paths, shell configuration, or runtime arguments.

## Validation

- Debug build completed
- Release build with `CUMETAL_ENABLE_BINARY_SHIM=OFF` completed
- fresh installed-prefix `vectorAdd` compile and Apple-GPU execution passed in both configurations
- focused installer, version, CLI, and negative-path tests passed
- broad non-benchmark suite: 210/218 passed; two generated-reference ordering failures passed serially, while six external PhysX jobs remain blocked by the sibling PhysX checkout being configured for Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `cumetal` command-line tool with version, environment diagnostics, and runtime launching.
  * Added Homebrew and prefix-based installation support, including manifest-backed uninstall.
  * Added installed-toolchain validation and end-to-end workflow checks.
* **Bug Fixes**
  * Improved command execution when `PATH` contains spaces.
  * Strengthened installer validation and prevented unintended shell configuration changes.
  * Updated release version to 0.1.0.
* **Documentation**
  * Added installation, usage, runtime compatibility, troubleshooting, known limitations, and security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->