### PR TITLE
Prepare CuMetal 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to CuMetal are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-30
+
 ### Fixed
 
 - **`cumetalc` no longer prints spurious `+ptxNN` target-feature warnings.** PTX version features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(cumetal VERSION 0.1.1 LANGUAGES C CXX OBJCXX)
+project(cumetal VERSION 0.1.2 LANGUAGES C CXX OBJCXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/runtime/api/cumetal_native.h
+++ b/runtime/api/cumetal_native.h
@@ -17,8 +17,8 @@ extern "C" {
  * fails the build's test suite if the two ever drift. */
 #define CUMETAL_VERSION_MAJOR 0
 #define CUMETAL_VERSION_MINOR 1
-#define CUMETAL_VERSION_PATCH 1
-#define CUMETAL_VERSION_STRING "0.1.1"
+#define CUMETAL_VERSION_PATCH 2
+#define CUMETAL_VERSION_STRING "0.1.2"
 
 /* Encoded as major*10000 + minor*100 + patch, so versions compare with < and >. */
 #define CUMETAL_VERSION \


### PR DESCRIPTION
## Summary

- bump CuMetal to 0.1.2
- publish the device-scoped PTX feature fix as a patch release
- close the matching changelog section

## Validation

- Release build with `CUMETAL_ENABLE_BINARY_SHIM=OFF`
- version synchronization test
- CLI and installer tests
- linked and freshly installed `vectorAdd.cu` executable tests
