### PR TITLE
Remove bundled vectorAdd example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to CuMetal are documented here. Format follows
 
 ## [Unreleased]
 
+### Removed
+
+- **The installed `vectorAdd.cu` copy and its `cumetal doctor` suggestion have been removed.**
+  Doctor now reports installation health only and ends at `No issues found!`.
+
 ## [0.1.2] - 2026-07-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to CuMetal are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-30
+
 ### Removed
 
 - **The installed `vectorAdd.cu` copy and its `cumetal doctor` suggestion have been removed.**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(cumetal VERSION 0.1.2 LANGUAGES C CXX OBJCXX)
+project(cumetal VERSION 0.1.3 LANGUAGES C CXX OBJCXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,8 +760,3 @@ install(FILES
     runtime/api/cub/device/device_merge_sort.h
     DESTINATION include/cub/device
 )
-
-install(FILES
-    samples/vectorAdd/vectorAdd.cu
-    DESTINATION share/cumetal/examples
-)

--- a/runtime/api/cumetal_native.h
+++ b/runtime/api/cumetal_native.h
@@ -17,8 +17,8 @@ extern "C" {
  * fails the build's test suite if the two ever drift. */
 #define CUMETAL_VERSION_MAJOR 0
 #define CUMETAL_VERSION_MINOR 1
-#define CUMETAL_VERSION_PATCH 2
-#define CUMETAL_VERSION_STRING "0.1.2"
+#define CUMETAL_VERSION_PATCH 3
+#define CUMETAL_VERSION_STRING "0.1.3"
 
 /* Encoded as major*10000 + minor*100 + patch, so versions compare with < and >. */
 #define CUMETAL_VERSION \

--- a/tests/functional/run_installed_cumetalc_link_executable.sh
+++ b/tests/functional/run_installed_cumetalc_link_executable.sh
@@ -30,20 +30,9 @@ if [[ -e "$HOME_DIR/.zshrc" ]]; then
 fi
 
 "$PREFIX/bin/cumetal" doctor
-INSTALLED_EXAMPLE="$PREFIX/share/cumetal/examples/vectorAdd.cu"
-if [[ ! -f "$INSTALLED_EXAMPLE" ]]; then
-  echo "FAIL: installed doctor example is missing: $INSTALLED_EXAMPLE" >&2
-  exit 1
-fi
-cmp "$SOURCE_CU" "$INSTALLED_EXAMPLE"
-if ! NO_COLOR=1 "$PREFIX/bin/cumetal" doctor | grep -qF \
-    "cumetalc '$INSTALLED_EXAMPLE' -o /tmp/vectorAdd"; then
-  echo "FAIL: doctor did not print a copy-paste command for the installed example" >&2
-  exit 1
-fi
 bash "$LINK_TEST" \
   "$PREFIX/bin/cumetalc" \
-  "$INSTALLED_EXAMPLE" \
+  "$SOURCE_CU" \
   "$TMP_ROOT/compile-and-run"
 
 echo "PASS: a fresh installed prefix compiled and ran unmodified CUDA source"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -576,5 +576,4 @@ add_test(
             ${CMAKE_CURRENT_SOURCE_DIR}/run_cumetal_cli_test.sh
             $<TARGET_FILE:cumetal>
             $<TARGET_FILE_DIR:cumetal_runtime>
-            ${CMAKE_SOURCE_DIR}/samples/vectorAdd/vectorAdd.cu
 )

--- a/tests/unit/run_cumetal_cli_test.sh
+++ b/tests/unit/run_cumetal_cli_test.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 CUMETAL="${1:?usage: run_cumetal_cli_test.sh <cumetal> <runtime-directory>}"
 RUNTIME_DIR="${2:?}"
-EXAMPLE="${3:?}"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -14,7 +13,11 @@ DOCTOR_OUTPUT="$(NO_COLOR=1 "$CUMETAL" doctor)"
 grep -qF '[✓] Apple Silicon' <<<"$DOCTOR_OUTPUT"
 grep -qF '[✓] CuMetal ' <<<"$DOCTOR_OUTPUT"
 grep -qF '[•] Binary compatibility shim' <<<"$DOCTOR_OUTPUT"
-grep -qF "cumetalc '$EXAMPLE' -o /tmp/vectorAdd" <<<"$DOCTOR_OUTPUT"
+grep -qF 'No issues found!' <<<"$DOCTOR_OUTPUT"
+if [[ "$DOCTOR_OUTPUT" == *"vectorAdd"* || "$DOCTOR_OUTPUT" == *"Try the bundled"* ]]; then
+  echo "FAIL: doctor output still advertises the removed bundled example" >&2
+  exit 1
+fi
 if [[ "$DOCTOR_OUTPUT" == *$'\033['* ]]; then
   echo "FAIL: NO_COLOR doctor output contained ANSI escapes" >&2
   exit 1

--- a/tests/unit/run_install_uninstall_test.sh
+++ b/tests/unit/run_install_uninstall_test.sh
@@ -30,7 +30,7 @@ test -x "$PREFIX/bin/cumetalc"
 test -f "$PREFIX/lib/libcumetal.dylib"
 test -f "$PREFIX/include/cuda.h"
 test -f "$PREFIX/include/cuda_runtime.h"
-test -f "$PREFIX/share/cumetal/examples/vectorAdd.cu"
+test ! -e "$PREFIX/share/cumetal/examples/vectorAdd.cu"
 test -x "$PREFIX/uninstall.sh"
 test -f "$PREFIX/share/cumetal/install_manifest.txt"
 

--- a/tools/cumetal/main.cpp
+++ b/tools/cumetal/main.cpp
@@ -70,15 +70,13 @@ struct Layout {
   std::filesystem::path bin_dir;
   std::filesystem::path include_dir;
   std::filesystem::path lib_dir;
-  std::filesystem::path vector_add_example;
 };
 
 Layout resolve_layout(const char *argv0) {
   if (const char *root = std::getenv("CUMETAL_ROOT");
       root != nullptr && root[0] != '\0') {
     const std::filesystem::path prefix(root);
-    return {prefix, prefix / "bin", prefix / "include", prefix / "lib",
-            prefix / "share" / "cumetal" / "examples" / "vectorAdd.cu"};
+    return {prefix, prefix / "bin", prefix / "include", prefix / "lib"};
   }
 
   const std::filesystem::path self = executable_path(argv0);
@@ -86,15 +84,12 @@ Layout resolve_layout(const char *argv0) {
   const std::filesystem::path prefix = bin_dir.parent_path();
   if (std::filesystem::exists(prefix / "include" / "cuda_runtime.h") &&
       std::filesystem::exists(prefix / "lib" / "libcumetal.dylib")) {
-    return {prefix, bin_dir, prefix / "include", prefix / "lib",
-            prefix / "share" / "cumetal" / "examples" / "vectorAdd.cu"};
+    return {prefix, bin_dir, prefix / "include", prefix / "lib"};
   }
 
   return {prefix, bin_dir,
           std::filesystem::path(CUMETAL_SOURCE_DIR) / "runtime" / "api",
-          bin_dir,
-          std::filesystem::path(CUMETAL_SOURCE_DIR) / "samples" / "vectorAdd" /
-              "vectorAdd.cu"};
+          bin_dir};
 }
 
 void print_usage(const char *argv0) {
@@ -161,10 +156,6 @@ public:
               << (color_ ? "\033[0m" : "") << '\n';
   }
 
-  void command(std::string_view command) const {
-    std::cout << "  " << style("\033[36m", command) << '\n';
-  }
-
 private:
   std::string style(const char *code, std::string_view text) const {
     if (!color_)
@@ -174,18 +165,6 @@ private:
 
   bool color_;
 };
-
-std::string shell_quote(std::string_view value) {
-  std::string quoted = "'";
-  for (const char ch : value) {
-    if (ch == '\'')
-      quoted += "'\\''";
-    else
-      quoted += ch;
-  }
-  quoted += "'";
-  return quoted;
-}
 
 int doctor(const char *argv0) {
   const Layout layout = resolve_layout(argv0);
@@ -223,14 +202,12 @@ int doctor(const char *argv0) {
       std::filesystem::exists(layout.include_dir / "cuda_runtime.h");
   const bool runtime =
       std::filesystem::exists(layout.lib_dir / "libcumetal.dylib");
-  const bool example = std::filesystem::exists(layout.vector_add_example);
-  ready &=
-      console.check(compiler && headers && runtime && example,
-                    std::string("CuMetal ") + CUMETAL_VERSION_STRING,
-                    {"Compiler: " + (layout.bin_dir / "cumetalc").string(),
-                     "Headers: " + layout.include_dir.string(),
-                     "Runtime: " + layout.lib_dir.string(),
-                     "Bundled example: " + layout.vector_add_example.string()});
+  ready &= console.check(
+      compiler && headers && runtime,
+      std::string("CuMetal ") + CUMETAL_VERSION_STRING,
+      {"Compiler: " + (layout.bin_dir / "cumetalc").string(),
+       "Headers: " + layout.include_dir.string(),
+       "Runtime: " + layout.lib_dir.string()});
 
   std::filesystem::path clang;
   if (const char *configured = std::getenv("CUMETAL_CUDA_CLANG");
@@ -279,11 +256,6 @@ int doctor(const char *argv0) {
   if (ready) {
     std::cout << '\n';
     console.success("No issues found!");
-    std::cout << "\nTry the bundled vectorAdd example:\n";
-    console.command("cumetalc " +
-                    shell_quote(layout.vector_add_example.string()) +
-                    " -o /tmp/vectorAdd");
-    console.command("/tmp/vectorAdd");
     return 0;
   }
   std::cerr << '\n';


### PR DESCRIPTION
## Summary

- stop installing the bundled `vectorAdd.cu` copy
- remove the example check, path, and commands from `cumetal doctor`
- keep the source-tree sample only as an internal compiler fixture
- prepare the v0.1.3 patch release

## User impact

`cumetal doctor` now reports installation health only and ends cleanly at `No issues found!`. The Homebrew package no longer contains `share/cumetal/examples/vectorAdd.cu`.

## Validation

- Release build with `CUMETAL_ENABLE_BINARY_SHIM=OFF`
- CLI and version synchronization tests
- install/uninstall manifest test asserting the example is absent
- linked and freshly installed compiler executable tests
