### PR TITLE
Add layered CI groundwork and LLVM compatibility

### DIFF
--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -1,0 +1,83 @@
+name: Hosted CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: ${{ matrix.name }}
+    runs-on: macos-15
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: release-shim-off
+            build_type: Release
+            binary_shim: "OFF"
+          - name: debug-shim-on
+            build_type: Debug
+            binary_shim: "ON"
+
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: "3"
+      CTEST_PARALLEL_LEVEL: "3"
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Select LLVM 18 toolchain
+        shell: bash
+        run: |
+          llvm_root="$(brew --prefix llvm@18)"
+          echo "${llvm_root}/bin" >> "${GITHUB_PATH}"
+          echo "CMAKE_PREFIX_PATH=${llvm_root}" >> "${GITHUB_ENV}"
+          echo "CUMETAL_CUDA_CLANG=${llvm_root}/bin/clang++" >> "${GITHUB_ENV}"
+          "${llvm_root}/bin/clang++" --version
+          cmake --version
+
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCUMETAL_BUILD_TESTS=ON \
+            -DCUMETAL_ENABLE_CUDA_REGISTRATION=ON \
+            -DCUMETAL_ENABLE_BINARY_SHIM=${{ matrix.binary_shim }}
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run hosted compiler and host tests
+        shell: bash
+        run: |
+          bash scripts/ci_report.sh build \
+            --require-tests \
+            --label-regex '^hosted$'
+
+      - name: Verify install layout
+        shell: bash
+        env:
+          INSTALL_PREFIX: ${{ runner.temp }}/cumetal-${{ matrix.name }}
+          EXPECT_BINARY_SHIM: ${{ matrix.binary_shim }}
+        run: |
+          cmake --install build --prefix "${INSTALL_PREFIX}"
+          "${INSTALL_PREFIX}/bin/cumetalc" --version
+          test -x "${INSTALL_PREFIX}/libexec/cumetal/cuda_toolchain/ptxas"
+          test -x "${INSTALL_PREFIX}/libexec/cumetal/cuda_toolchain/fatbinary"
+          test -L "${INSTALL_PREFIX}/lib/libcublas.dylib"
+          if [[ "${EXPECT_BINARY_SHIM}" == "ON" ]]; then
+            test -L "${INSTALL_PREFIX}/lib/libcuda.dylib"
+          else
+            test ! -e "${INSTALL_PREFIX}/lib/libcuda.dylib"
+          fi

--- a/.github/workflows/gpu-ci.yml.disabled
+++ b/.github/workflows/gpu-ci.yml.disabled
@@ -1,0 +1,97 @@
+name: Apple GPU CI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apple-gpu-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gpu-correctness:
+    # Pushes run only after the repository variable is enabled. A manual
+    # dispatch always attempts the job, which is useful while commissioning a
+    # runner. Pull requests never execute untrusted code on the self-hosted Mac.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      vars.CUMETAL_GPU_CI_ENABLED == 'true'
+    name: ${{ matrix.name }}
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - ci-m1
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - name: release-shim-off
+            build_type: Release
+            binary_shim: "OFF"
+          - name: debug-shim-on
+            build_type: Debug
+            binary_shim: "ON"
+
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: "4"
+      CUMETAL_CACHE_DIR: >-
+        ${{ runner.temp }}/cumetal-cache-${{ matrix.name }}-${{ github.run_id }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Verify Apple GPU prerequisites
+        shell: bash
+        run: |
+          test "$(uname -m)" = "arm64"
+          xcrun --find metal
+          xcrun --find metallib
+          cmake --version
+
+          if llvm_root="$(brew --prefix llvm@18 2>/dev/null)"; then
+            :
+          else
+            llvm_root="$(brew --prefix llvm)"
+          fi
+          echo "${llvm_root}/bin" >> "${GITHUB_PATH}"
+          echo "CMAKE_PREFIX_PATH=${llvm_root}" >> "${GITHUB_ENV}"
+          echo "CUMETAL_CUDA_CLANG=${llvm_root}/bin/clang++" >> "${GITHUB_ENV}"
+
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -S . -B build-gpu \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCUMETAL_BUILD_TESTS=ON \
+            -DCUMETAL_ENABLE_CUDA_REGISTRATION=ON \
+            -DCUMETAL_ENABLE_BINARY_SHIM=${{ matrix.binary_shim }}
+
+      - name: Build
+        run: cmake --build build-gpu
+
+      - name: Require positive GPU proof
+        shell: bash
+        run: |
+          bash scripts/ci_report.sh build-gpu \
+            --require-tests \
+            --require-no-skips \
+            --tests-regex \
+            '^(air_abi_emit_load_xcrun|functional_runtime_vector_add|functional_runtime_stream_vector_add|functional_runtime_atomic|functional_runtime_warp_partial_mask|functional_cumetalc_link_executable|ptx_sweep_numeric)$' \
+            --parallel 1
+
+      - name: Run full correctness suite
+        shell: bash
+        run: |
+          bash scripts/ci_report.sh build-gpu \
+            --require-tests \
+            --exclude-regex '(^bench_|unit_cumetal_bench_ratio_gate$)' \
+            --parallel 1

--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ passing test. A skip is not evidence of compatibility. A correct answer without
 GPU provenance may be a CPU fallback. The test policy exists because all three
 mistakes have happened before.
 
+The hosted and Apple-GPU CI definitions are temporarily disabled and retained
+as `.github/workflows/*.yml.disabled` for later re-enablement. The equivalent
+local test selections and runner contract remain documented in
+[docs/testing.md](docs/testing.md).
+
 ## Tools
 
 | Tool | Job |

--- a/compiler/cumetalc/main.cpp
+++ b/compiler/cumetalc/main.cpp
@@ -318,6 +318,26 @@ std::filesystem::path find_cuda_clang(
     return {};
 }
 
+bool clang_supports_inline_all_viable_calls(const std::filesystem::path& clang) {
+    const CommandResult help = run_command_capture(
+        quote_shell(clang.string()) + " -cc1 -mllvm --help-hidden 2>&1");
+    return help.started &&
+           help.output.find("-inline-all-viable-calls") != std::string::npos;
+}
+
+std::string cuda_inline_flags(const std::filesystem::path& clang,
+                              const std::string& threshold) {
+    if (threshold.empty()) return {};
+    std::string flags = " -fgpu-inline-threshold=" + quote_shell(threshold);
+    // LLVM 22 added the stronger all-viable-calls switch. Older supported
+    // Clang versions reject it during option parsing, so retain their GPU
+    // inlining threshold without passing an unknown backend option.
+    if (clang_supports_inline_all_viable_calls(clang)) {
+        flags += " -mllvm -inline-all-viable-calls";
+    }
+    return flags;
+}
+
 std::filesystem::path find_llvm_opt(const std::filesystem::path& clang) {
     const std::filesystem::path sibling = clang.parent_path() / "opt";
     if (std::filesystem::exists(sibling)) return sibling;
@@ -331,6 +351,16 @@ std::filesystem::path find_llvm_opt(const std::filesystem::path& clang) {
         if (!path.empty()) return path;
     }
     return {};
+}
+
+std::string llvm_lower_switch_pass(const std::filesystem::path& llvm_opt) {
+    const CommandResult passes =
+        run_command_capture(quote_shell(llvm_opt.string()) + " --print-passes 2>&1");
+    if (passes.started && passes.output.find("lower-switch") != std::string::npos) {
+        return "lower-switch";
+    }
+    // LLVM 18 used the unhyphenated new-pass-manager spelling.
+    return "lowerswitch";
 }
 
 std::string ptx_feature_for_arch(std::string_view arch) {
@@ -438,10 +468,10 @@ int run_executable_driver(const ExecutableDriverOptions& options, const char* ar
     // Clang execs the shims as subprocesses, so they must be found via PATH. Prepend rather than
     // replace so a user-provided toolchain earlier in PATH still loses to ours deliberately.
     const char* existing_path = std::getenv("PATH");
-    const std::string path_prefix =
-        "PATH=" + quote_shell(layout.toolchain_dir.string()) + ":" +
-        (existing_path != nullptr ? std::string(existing_path) : std::string("/usr/bin:/bin")) +
-        " ";
+    const std::string child_path =
+        layout.toolchain_dir.string() + ":" +
+        (existing_path != nullptr ? std::string(existing_path) : std::string("/usr/bin:/bin"));
+    const std::string path_prefix = "PATH=" + quote_shell(child_path) + " ";
 
     std::string compile = path_prefix + quote_shell(compiler.string()) +
                           " -x cuda -std=c++17 -O2"
@@ -453,10 +483,7 @@ int run_executable_driver(const ExecutableDriverOptions& options, const char* ar
                           " -I " +
                           quote_shell(layout.include_dir.string()) + " -include " +
                           quote_shell("cuda_runtime.h");
-    if (!options.cuda_inline_threshold.empty()) {
-        compile += " -fgpu-inline-threshold=" + quote_shell(options.cuda_inline_threshold) +
-                   " -mllvm -inline-all-viable-calls";
-    }
+    compile += cuda_inline_flags(compiler, options.cuda_inline_threshold);
     for (const auto& dir : options.include_dirs) {
         compile += " -I " + quote_shell(dir.string());
     }
@@ -810,10 +837,7 @@ int main(int argc, char** argv) {
             " -Xclang -target-feature -Xclang +ptx70"
             " -nocudainc -nocudalib -Wno-unknown-cuda-version -Wno-pass-failed"
             " -D__CUDACC__=1 -D__NVCC__=1";
-        if (!cuda_inline_threshold.empty()) {
-            command += " -fgpu-inline-threshold=" + quote_shell(cuda_inline_threshold) +
-                       " -mllvm -inline-all-viable-calls";
-        }
+        command += cuda_inline_flags(compiler, cuda_inline_threshold);
         if (std::filesystem::exists(runtime_api_dir) &&
             std::filesystem::is_directory(runtime_api_dir)) {
             command += " -I " + quote_shell(runtime_api_dir.string()) +
@@ -1088,7 +1112,8 @@ int main(int argc, char** argv) {
             }
             const std::string opt_command =
                 quote_shell(llvm_opt.string()) +
-                " -S -passes=sroa,mem2reg,dce,simplifycfg,lower-switch " +
+                " -S -passes=sroa,mem2reg,dce,simplifycfg," +
+                llvm_lower_switch_pass(llvm_opt) + " " +
                 quote_shell(raw_device_ll.string()) + " -o " +
                 quote_shell(device_ll.string()) + " 2>&1";
             const CommandResult opt_result = run_command_capture(opt_command);

--- a/compiler/ir/src/nvvm_importer.cpp
+++ b/compiler/ir/src/nvvm_importer.cpp
@@ -8,6 +8,8 @@
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/MapVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Config/llvm-config.h>
 #include <llvm/IR/CFG.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DebugInfoMetadata.h>
@@ -22,6 +24,7 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/TargetParser/Triple.h>
 
 #include <algorithm>
 #include <map>
@@ -351,6 +354,32 @@ MemoryOrdering import_ordering(llvm::AtomicOrdering ordering) {
     return MemoryOrdering::kNone;
 }
 
+bool is_nvvm_kernel(const llvm::Function& function) {
+    if (function.getCallingConv() == llvm::CallingConv::PTX_Kernel) {
+        return true;
+    }
+    const llvm::Module* module = function.getParent();
+    const llvm::NamedMDNode* annotations =
+        module != nullptr ? module->getNamedMetadata("nvvm.annotations") : nullptr;
+    if (annotations == nullptr) return false;
+
+    for (const llvm::MDNode* annotation : annotations->operands()) {
+        if (annotation == nullptr || annotation->getNumOperands() < 2) continue;
+        const auto* annotated_value =
+            llvm::dyn_cast_or_null<llvm::ValueAsMetadata>(
+                annotation->getOperand(0).get());
+        const auto* property =
+            llvm::dyn_cast_or_null<llvm::MDString>(
+                annotation->getOperand(1).get());
+        if (annotated_value != nullptr &&
+            annotated_value->getValue() == &function &&
+            property != nullptr && property->getString() == "kernel") {
+            return true;
+        }
+    }
+    return false;
+}
+
 struct FunctionState {
     Function output;
     std::unordered_map<const llvm::Value*, ValueId> values;
@@ -404,8 +433,7 @@ struct Importer {
 
     bool allocate_function(const llvm::Function& function, FunctionState* state) {
         state->output.name = function.getName().str();
-        state->output.is_kernel =
-            function.getCallingConv() == llvm::CallingConv::PTX_Kernel;
+        state->output.is_kernel = is_nvvm_kernel(function);
         state->output.return_type = import_type(function.getReturnType());
         state->output.generic_pointer_return =
             function.getReturnType()->isPointerTy() &&
@@ -562,8 +590,11 @@ struct Importer {
             if (assembly == nullptr) {
                 return fail(&call, "malformed LLVM inline assembly call");
             }
-            const std::string text = assembly->getAsmString().str();
-            if (text.find("mov.u32 $0, %laneid") != std::string::npos) {
+            const std::string text = llvm::StringRef(assembly->getAsmString()).str();
+            if (text.find("mov.u32 $0, %activemask") != std::string::npos) {
+                operation->opcode = OpCode::kBallot;
+                operation->attributes["kind"] = "active_mask";
+            } else if (text.find("mov.u32 $0, %laneid") != std::string::npos) {
                 operation->opcode = OpCode::kLaneId;
             } else if (text.find("shfl.sync.idx.b32") != std::string::npos) {
                 operation->opcode = OpCode::kShuffle;
@@ -1074,7 +1105,11 @@ struct Importer {
             }
         } else if (const auto* gep = llvm::dyn_cast<llvm::GetElementPtrInst>(&instruction)) {
             constexpr unsigned kPointerBits = 64;
+#if LLVM_VERSION_MAJOR >= 20
             llvm::SmallMapVector<llvm::Value*, llvm::APInt, 4> variable_offsets;
+#else
+            llvm::MapVector<llvm::Value*, llvm::APInt> variable_offsets;
+#endif
             llvm::APInt constant_offset(kPointerBits, 0, true);
             if (!gep->collectOffset(input->getDataLayout(), kPointerBits,
                                     variable_offsets, constant_offset)) {
@@ -1221,7 +1256,7 @@ struct Importer {
             // atomic but relaxed (they are not memory fences). Preserve CUDA's
             // source semantics and map the operation to Metal's relaxed order.
             if (operation.memory_ordering == MemoryOrdering::kSequentiallyConsistent &&
-                input->getTargetTriple().isNVPTX()) {
+                llvm::Triple(input->getTargetTriple()).isNVPTX()) {
                 operation.memory_ordering = MemoryOrdering::kRelaxed;
                 operation.attributes["cuda_legacy_atomic"] = "true";
             }
@@ -1314,7 +1349,8 @@ struct Importer {
         result.module.stage = IrStage::kGpuSemantic;
         result.module.attributes["frontend"] = "nvvm";
         result.module.attributes["ir_schema"] = "1";
-        result.module.attributes["target_triple"] = module->getTargetTriple().str();
+        result.module.attributes["target_triple"] =
+            llvm::Triple(module->getTargetTriple()).str();
 
         for (const llvm::GlobalVariable& global : module->globals()) {
             if (global.getAddressSpace() == 3 && global.hasInitializer() &&
@@ -1363,7 +1399,7 @@ struct Importer {
                 result.error = "NVVM kernel not found: " + options.entry_name;
                 return std::move(result);
             }
-            if (root->getCallingConv() != llvm::CallingConv::PTX_Kernel) {
+            if (!is_nvvm_kernel(*root)) {
                 result.error = "selected NVVM entry is not a kernel: " + options.entry_name;
                 return std::move(result);
             }

--- a/compiler/passes/src/intrinsic_lower.cpp
+++ b/compiler/passes/src/intrinsic_lower.cpp
@@ -470,6 +470,17 @@ IntrinsicLowerResult lower_intrinsics(const cumetal::ptx::EntryFunction& entry,
             continue;
         }
 
+        // Tolerant module parsing is required so --entry can ignore
+        // unsupported neighboring kernels. Re-apply strictness to the selected
+        // entry here; otherwise a shared-root opcode such as
+        // cp.async.bulk.tensor could be mistaken for supported cp.async.
+        if (!instruction.supported) {
+            result.warnings.push_back(
+                "intrinsic_lower: no mapping for opcode '" + instruction.opcode + "'");
+            result.instructions.push_back(std::move(lowered));
+            continue;
+        }
+
         bool translated = false;
         translated = translated || map_special_register_mov(instruction, &lowered);
         translated = translated || map_barrier(instruction, &lowered);

--- a/docs/known-gaps.md
+++ b/docs/known-gaps.md
@@ -138,10 +138,10 @@ as gaps have been closed.
   lowering path. CUDA source compilation can therefore succeed while later
   strict PTX lowering still rejects an unimplemented opcode or libdevice call.
   Standalone PTX `.func` bodies are not lowered; projects can request aggressive
-  device inlining with `--cuda-inline-threshold`, which also forces every viable
-  reachable device call to inline. Recursion, indirect calls, and explicitly
-  non-inlineable helpers remain unsupported. The reduced PhysX rigid-body subset
-  uses this for helpers including `updateCacheAndBound` and
+  device inlining with `--cuda-inline-threshold`, which on LLVM 22+ also forces
+  every viable reachable device call to inline. Recursion, indirect calls, and
+  explicitly non-inlineable helpers remain unsupported. The reduced PhysX
+  rigid-body subset uses this for helpers including `updateCacheAndBound` and
   `getIncidentPolygon4`.
 - The older `.cu` mode without `--cuda-device` remains a qualifier-stripping
   host-LLVM prototype suitable only for simple patterns; it is not a general

--- a/docs/status.md
+++ b/docs/status.md
@@ -47,9 +47,20 @@ v1 toolchain-completeness work (2026-07-26):
   bash scripts/ci_report.sh build --exclude-regex '^bench_'
   ```
 
-  There is deliberately no CI (spec §10.7 is unimplemented). Both configurations —
-  Release/shim-off, which is what users install, and Debug/shim-on — must be run locally before
-  a change lands.
+  Layered GitHub Actions definitions exist for both configurations —
+  Release/shim-off, which is what users install, and Debug/shim-on — but are
+  temporarily disabled as `.github/workflows/*.yml.disabled`. When enabled,
+  the hosted lane runs only tests explicitly labelled `hosted`, requires a
+  non-empty selection, and verifies the installed prefix and shim layout.
+
+  Spec §10.7's Apple-GPU correctness layer is defined separately for a
+  self-hosted runner labelled `ci-m1`. When the workflow is re-enabled, it runs
+  on pushes to `main` after the `CUMETAL_GPU_CI_ENABLED=true` repository
+  variable is set and can be commissioned with a manual dispatch. A focused
+  GPU/provenance set uses
+  `--require-no-skips` before the full suite, so a missing device or Metal
+  toolchain cannot appear as a green hardware result. Pull requests do not run
+  untrusted code on the self-hosted machine.
 
 - **The performance gate no longer flakes under load.** `cumetal_bench` averaged its iterations,
   and a mean is dominated by its worst sample, so a single scheduler stall failed the 2× ceiling

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,6 +13,59 @@ inspect any long-lived skip with `ctest -V` before trusting it —
 cases where a skip concealed a real failure and one where a test had never
 executed on any machine.
 
+CI layers
+---------
+
+The workflow definitions are temporarily disabled by their `.yml.disabled`
+suffixes, so GitHub does not discover or run them. Rename them back to `.yml`
+to re-enable the gates described below.
+
+`.github/workflows/ci.yml.disabled` defines the hosted gate for pushes and pull
+requests. It uses the `macos-15` Apple Silicon image and covers both supported
+build policies:
+
+| Configuration | Purpose |
+| --- | --- |
+| Release + binary shim off | Shipping, source-first configuration |
+| Debug + binary shim on | Development and opt-in alias coverage |
+
+The hosted job builds the complete project, runs the CTest tests carrying the
+`hosted` label, and installs into a temporary prefix to check tools, CUDA
+toolchain shims, library aliases, and the conditional `libcuda.dylib` layout.
+The label contains parser, CFG/SSA, typed IR/MSL, PTX lowering, AIR container,
+negative-path, headers, CLI, cache, ABI registration, and packaging checks. It
+does not contain GPU execution tests. Hosted success is therefore a compiler
+and distribution claim, not an Apple-GPU execution claim.
+
+Run the same selection locally:
+
+```bash
+bash scripts/ci_report.sh build \
+  --require-tests \
+  --label-regex '^hosted$'
+```
+
+`.github/workflows/gpu-ci.yml.disabled` defines the spec §10.7 hardware layer.
+Its runner must have the standard self-hosted labels `self-hosted`, `macOS`,
+and `ARM64`, plus the custom label `ci-m1`. When enabled, it runs only on pushes
+to `main` and manual dispatch, never on pull requests. Set the repository Actions variable
+`CUMETAL_GPU_CI_ENABLED=true` after the runner is commissioned to enable the
+push trigger.
+
+The GPU workflow first runs a narrow proof set spanning Metal library loading,
+runtime launch, streams, atomics, warp masks, source-first executable linking,
+and numerical PTX execution. That selection uses both `--require-tests` and
+`--require-no-skips`. Only after every proof test executes does the workflow
+run the full correctness suite (excluding the separately managed benchmark
+gate), where optional external-project tests may still report explicit skips.
+
+The report policy flags are intentionally distinct:
+
+- `--require-tests` rejects an empty CTest label or regex selection.
+- `--require-no-skips` rejects any skip in a prerequisite-complete proof gate.
+- The full suite should not use `--require-no-skips`, because optional llm.c,
+  llama.cpp, PhysX, and multi-Xcode checks are environment-dependent.
+
 Runtime execution tests
 -----------------------
 

--- a/runtime/api/cuda_runtime.h
+++ b/runtime/api/cuda_runtime.h
@@ -1311,7 +1311,9 @@ static __device__ __forceinline__ unsigned int __ballot_sync(unsigned int mask, 
 }
 
 static __device__ __forceinline__ unsigned int __activemask(void) {
-    return __nvvm_activemask();
+    unsigned int active;
+    asm("mov.u32 %0, %%activemask;" : "=r"(active));
+    return active;
 }
 
 // Lane mask special registers: bitmasks of lanes with index R relative to current lane.

--- a/scripts/ci_report.sh
+++ b/scripts/ci_report.sh
@@ -6,22 +6,56 @@
 # "N% tests passed" hides how much of the suite never ran, so this script always surfaces the
 # skip count and lists the skipped tests by name.
 #
-# Usage: ci_report.sh <build-dir> [extra ctest args...]
+# Usage:
+#   ci_report.sh <build-dir> [--require-tests] [--require-no-skips] [ctest args...]
+#
+# --require-tests fails when the CTest selection is empty. This catches stale
+# label/regex selections that would otherwise make a CI job pass without
+# exercising anything.
+#
+# --require-no-skips fails when any selected test skips. Use it for narrow
+# hardware proof gates whose prerequisites are part of the gate. Do not use it
+# for the full suite, which intentionally contains external-project skips.
 set -uo pipefail
 
 BUILD_DIR="${1:?usage: ci_report.sh <build-dir> [ctest args...]}"
 shift || true
 
+REQUIRE_TESTS=0
+REQUIRE_NO_SKIPS=0
+CTEST_ARGS=()
+for argument in "$@"; do
+    case "${argument}" in
+        --require-tests)
+            REQUIRE_TESTS=1
+            ;;
+        --require-no-skips)
+            REQUIRE_NO_SKIPS=1
+            ;;
+        *)
+            CTEST_ARGS+=("${argument}")
+            ;;
+    esac
+done
+
 LOG="$(mktemp -t cumetal-ctest)"
 trap 'rm -f "${LOG}"' EXIT
 
-ctest --test-dir "${BUILD_DIR}" --output-on-failure "$@" 2>&1 | tee "${LOG}"
+ctest --test-dir "${BUILD_DIR}" --output-on-failure "${CTEST_ARGS[@]}" 2>&1 | tee "${LOG}"
 CTEST_STATUS="${PIPESTATUS[0]}"
 
 TOTAL=$(grep -cE '^[[:space:]]*[0-9]+/[0-9]+ Test' "${LOG}" || true)
 PASSED=$(grep -cE '\.\.\.[[:space:]]+Passed' "${LOG}" || true)
 SKIPPED=$(grep -cE '\.\.\.\*+Skipped' "${LOG}" || true)
 FAILED=$(grep -cE '\.\.\.\*+Failed|\.\.\.\*+Exception' "${LOG}" || true)
+
+POLICY_FAILURES=()
+if [[ "${REQUIRE_TESTS}" -eq 1 && "${TOTAL}" -eq 0 ]]; then
+    POLICY_FAILURES+=("CTest selection was empty (--require-tests).")
+fi
+if [[ "${REQUIRE_NO_SKIPS}" -eq 1 && "${SKIPPED}" -gt 0 ]]; then
+    POLICY_FAILURES+=("${SKIPPED} selected test(s) skipped (--require-no-skips).")
+fi
 
 {
     echo ""
@@ -54,6 +88,19 @@ FAILED=$(grep -cE '\.\.\.\*+Failed|\.\.\.\*+Exception' "${LOG}" || true)
             sed 's/^/- /'
         echo ""
     fi
+
+    if [[ "${#POLICY_FAILURES[@]}" -gt 0 ]]; then
+        echo "### CI policy failures"
+        echo ""
+        for failure in "${POLICY_FAILURES[@]}"; do
+            echo "- ${failure}"
+        done
+        echo ""
+    fi
 } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [[ "${CTEST_STATUS}" -eq 0 && "${#POLICY_FAILURES[@]}" -gt 0 ]]; then
+    exit 1
+fi
 
 exit "${CTEST_STATUS}"

--- a/tests/air_abi/CMakeLists.txt
+++ b/tests/air_abi/CMakeLists.txt
@@ -275,3 +275,21 @@ set_tests_properties(
     PROPERTIES
         SKIP_RETURN_CODE 77
 )
+
+# These checks exercise container parsing, negative paths, PTX/CUDA import,
+# typed lowering, and experimental metallib emission without loading a library
+# on a Metal device. They are the AIR/compiler slice safe for hosted CI.
+set_tests_properties(
+    air_abi_emit_validate_experimental
+    air_abi_validate_negative
+    air_abi_ptx_to_experimental_validate
+    air_abi_matrix_ptx_to_experimental_validate
+    air_abi_cumetalc_ptx_experimental_validate
+    air_abi_cumetalc_matrix_ptx_experimental_validate
+    air_abi_cumetalc_cu_experimental_validate
+    air_abi_cumetalc_cuda_device_frontend_validate
+    air_abi_cumetalc_cu_default_output_validate
+    air_abi_cumetalc_ptx_default_output_validate
+    air_abi_ptx2llvm_positional_default_output
+    PROPERTIES LABELS "hosted;air-compiler"
+)

--- a/tests/air_abi/run_cumetalc_cuda_device_frontend_validate.sh
+++ b/tests/air_abi/run_cumetalc_cuda_device_frontend_validate.sh
@@ -39,8 +39,27 @@ for argument in "$@"; do
   fi
   previous="${argument}"
 done
-if [[ "${threshold}" != true || "${force_inline}" != true ]]; then
-  echo "FAIL: CUDA frontend omitted forced viable-call inlining" >&2
+
+if [[ "$*" == *"-cc1"* && "$*" == *"--help-hidden"* ]]; then
+  exec "${CUMETAL_FRONTEND_REAL_CLANG}" "$@"
+fi
+
+supports_force_inline=false
+if "${CUMETAL_FRONTEND_REAL_CLANG}" -cc1 -mllvm --help-hidden 2>/dev/null |
+    grep -- '-inline-all-viable-calls' >/dev/null; then
+  supports_force_inline=true
+fi
+
+if [[ "${threshold}" != true ]]; then
+  echo "FAIL: CUDA frontend omitted the GPU inline threshold" >&2
+  exit 64
+fi
+if [[ "${supports_force_inline}" == true && "${force_inline}" != true ]]; then
+  echo "FAIL: CUDA frontend omitted supported viable-call inlining" >&2
+  exit 64
+fi
+if [[ "${supports_force_inline}" != true && "${force_inline}" == true ]]; then
+  echo "FAIL: CUDA frontend passed unsupported viable-call inlining" >&2
   exit 64
 fi
 exec "${CUMETAL_FRONTEND_REAL_CLANG}" "$@"

--- a/tests/functional/run_cumetalc_link_executable.sh
+++ b/tests/functional/run_cumetalc_link_executable.sh
@@ -34,7 +34,10 @@ rm -f "${OUT_BIN}"
 echo "Building ${SOURCE_CU} -> ${OUT_BIN}"
 BUILD_LOG="${WORK_DIR}/link_executable.build.log"
 BUILD_STATUS=0
-"${CUMETALC}" "${SOURCE_CU}" -o "${OUT_BIN}" >"${BUILD_LOG}" 2>&1 || BUILD_STATUS=$?
+# Keep a space-bearing PATH entry in this regression gate. The driver prepends its
+# CUDA shims to PATH when invoking Clang and must preserve the caller's value.
+PATH="${WORK_DIR}/path with spaces:${PATH}" \
+    "${CUMETALC}" "${SOURCE_CU}" -o "${OUT_BIN}" >"${BUILD_LOG}" 2>&1 || BUILD_STATUS=$?
 
 # Homebrew LLVM emits a benign "'+ptxNN' is not a recognized feature" line on toolchains new
 # enough not to need the flag. Filter it from the printed log only, never from the exit status.

--- a/tests/ptx_sweep/CMakeLists.txt
+++ b/tests/ptx_sweep/CMakeLists.txt
@@ -40,3 +40,10 @@ add_test(
 )
 
 set_tests_properties(ptx_sweep_numeric PROPERTIES SKIP_RETURN_CODE 77)
+
+set_tests_properties(
+    ptx_sweep_supported_ops
+    ptx_sweep_unsupported_ops
+    PROPERTIES LABELS "hosted;ptx-lowering"
+)
+set_tests_properties(ptx_sweep_numeric PROPERTIES LABELS "gpu")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -565,3 +565,18 @@ add_test(
             $<TARGET_FILE:cumetalc>
             ${CMAKE_SOURCE_DIR}/runtime/api/cumetal_native.h
 )
+
+add_test(
+    NAME unit_ci_report
+    COMMAND bash
+            ${CMAKE_CURRENT_SOURCE_DIR}/run_ci_report_test.sh
+            ${CMAKE_SOURCE_DIR}/scripts/ci_report.sh
+)
+
+# Hosted CI deliberately selects tests by capability rather than by name.
+# Keep GPU execution out of this label so a hosted runner cannot turn a
+# missing Metal device into a green-but-skipped hardware claim.
+get_property(CUMETAL_UNIT_TESTS DIRECTORY PROPERTY TESTS)
+list(REMOVE_ITEM CUMETAL_UNIT_TESTS unit_cumetal_bench_ratio_gate)
+set_tests_properties(${CUMETAL_UNIT_TESTS} PROPERTIES LABELS "hosted;unit")
+set_tests_properties(unit_cumetal_bench_ratio_gate PROPERTIES LABELS "gpu")

--- a/tests/unit/nvvm_ir_msl_test.cpp
+++ b/tests/unit/nvvm_ir_msl_test.cpp
@@ -722,6 +722,21 @@ entry:
 }
 )llvm";
 
+constexpr const char* kNvvmInlineActiveMask = R"llvm(
+target datalayout = "e-p:64:64-i64:64-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+define void @inline_active_mask(ptr %out) {
+entry:
+  %active = call i32 asm "mov.u32 $0, %activemask;", "=r"()
+  store i32 %active, ptr %out, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!0 = !{ptr @inline_active_mask, !"kernel", i32 1}
+)llvm";
+
 }  // namespace
 
 int main() {
@@ -1110,6 +1125,14 @@ int main() {
                      warp_votes.source.find("thread_index_in_simdgroup") !=
                          std::string::npos,
                  "masked CUDA warp votes lower to Metal SIMD vote semantics");
+
+    const metal::NvvmToMslResult inline_active_mask =
+        metal::compile_nvvm_to_msl(
+            kNvvmInlineActiveMask, "inline-active-mask.ll", "inline_active_mask");
+    ok &= expect(inline_active_mask.ok &&
+                     inline_active_mask.source.find("simd_active_threads_mask()") !=
+                         std::string::npos,
+                 "Clang-compatible inline activemask lowers to the Metal active-lane mask");
 
     if (!ok) return 1;
     std::cout << "NVVM -> CuMetal IR -> typed MSL tests passed\n";

--- a/tests/unit/run_ci_report_test.sh
+++ b/tests/unit/run_ci_report_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <ci-report-script>" >&2
+    exit 2
+fi
+
+REPORT_SCRIPT="$1"
+TEST_ROOT="$(mktemp -d -t cumetal-ci-report-test)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+mkdir -p "${TEST_ROOT}/bin"
+cat >"${TEST_ROOT}/bin/ctest" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+case "${FAKE_CTEST_RESULT:-pass}" in
+    pass)
+        cat <<'OUTPUT'
+Test project /tmp/cumetal
+    Start 1: fixture_pass
+1/1 Test #1: fixture_pass .....................   Passed    0.01 sec
+100% tests passed, 0 tests failed out of 1
+OUTPUT
+        exit 0
+        ;;
+    skip)
+        cat <<'OUTPUT'
+Test project /tmp/cumetal
+    Start 1: fixture_skip
+1/1 Test #1: fixture_skip .....................***Skipped   0.01 sec
+100% tests passed, 0 tests failed out of 1
+OUTPUT
+        exit 0
+        ;;
+    empty)
+        cat <<'OUTPUT'
+Test project /tmp/cumetal
+No tests were found!!!
+OUTPUT
+        exit 0
+        ;;
+    fail)
+        cat <<'OUTPUT'
+Test project /tmp/cumetal
+    Start 1: fixture_fail
+1/1 Test #1: fixture_fail .....................***Failed    0.01 sec
+0% tests passed, 1 tests failed out of 1
+OUTPUT
+        exit 8
+        ;;
+    *)
+        echo "unexpected fake result: ${FAKE_CTEST_RESULT}" >&2
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "${TEST_ROOT}/bin/ctest"
+
+run_report() {
+    PATH="${TEST_ROOT}/bin:${PATH}" \
+        GITHUB_STEP_SUMMARY="${TEST_ROOT}/summary.md" \
+        FAKE_CTEST_RESULT="$1" \
+        bash "${REPORT_SCRIPT}" "${TEST_ROOT}/build" "${@:2}" \
+        >"${TEST_ROOT}/output.log" 2>&1
+}
+
+run_report pass --require-tests --require-no-skips --label-regex '^hosted$'
+run_report skip --require-tests
+
+if run_report skip --require-tests --require-no-skips; then
+    echo "FAIL: --require-no-skips accepted a skipped test" >&2
+    exit 1
+fi
+if ! grep -q 'selected test(s) skipped' "${TEST_ROOT}/output.log"; then
+    echo "FAIL: skipped-test policy failure was not reported" >&2
+    exit 1
+fi
+
+if run_report empty --require-tests; then
+    echo "FAIL: --require-tests accepted an empty selection" >&2
+    exit 1
+fi
+if ! grep -q 'CTest selection was empty' "${TEST_ROOT}/output.log"; then
+    echo "FAIL: empty-selection policy failure was not reported" >&2
+    exit 1
+fi
+
+if run_report fail; then
+    echo "FAIL: the underlying CTest failure status was lost" >&2
+    exit 1
+fi
+
+echo "PASS: ci_report policy gates reject skips and empty selections"


### PR DESCRIPTION
## What changed

- add hosted and Apple-GPU GitHub Actions definitions, retained with `.yml.disabled` suffixes so no workflow runs yet
- add explicit hosted/GPU CTest labels and CI policy gates for empty selections and unexpected skips
- make the CUDA/NVVM frontend compatible with supported LLVM 18 and current LLVM 22 toolchains
- harden linked CUDA executable compilation when `PATH` contains spaces
- document the disabled workflow state and the future self-hosted runner contract

## Why

CuMetal needed layered, independently trustworthy compiler and Apple-GPU validation. Exercising the hosted design against LLVM 18 exposed API, kernel-annotation, activemask, optimizer-pass, and inlining-option differences that prevented the documented minimum toolchain from building and testing reliably.

## Impact

The CI definitions can be enabled later by renaming them back to `.yml`. Until then GitHub discovers no workflows. Local test reporting now fails closed for empty selections, and focused hardware gates can require zero skips.

## Validation

- LLVM 18 Release/shim-off hosted gate: 47/47 passed
- LLVM 18 Debug/shim-on hosted gate: 50/50 passed
- focused Apple-GPU proof: 7/7 passed, zero skips
- LLVM 22 targeted compatibility checks: 2/2 passed
- shell syntax, workflow YAML parsing, and `git diff --check`

Unrelated uncommitted PhysX, Metal backend, conformance, phase-one, and video work was intentionally excluded.