### PR TITLE
Cache the inline-launch ABI sidecar parse instead of re-reading it every kernel launch

### DIFF
--- a/runtime/rt/cuda_runtime.cpp
+++ b/runtime/rt/cuda_runtime.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <string_view>
 #include <sstream>
+#include <sys/stat.h>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -55,12 +56,10 @@ void trace_op(const char* tag, const char* detail) {
     std::fflush(stderr);
 }
 
-bool load_inline_static_shared_bytes(const char* metallib_path,
-                                     const char* expected_kernel,
-                                     std::size_t* out_bytes) {
-    if (metallib_path == nullptr || expected_kernel == nullptr || out_bytes == nullptr) {
-        return false;
-    }
+// Uncached parse; callers should go through load_inline_static_shared_bytes below.
+bool load_inline_static_shared_bytes_uncached(const char* metallib_path,
+                                              const char* expected_kernel,
+                                              std::size_t* out_bytes) {
     *out_bytes = 0;
     std::ifstream abi(std::string(metallib_path) + ".cumetal-abi");
     if (!abi) {
@@ -118,6 +117,51 @@ bool load_inline_static_shared_bytes(const char* metallib_path,
         return false;
     }
     return true;
+}
+
+struct InlineAbiCacheEntry {
+    bool valid = false;
+    std::size_t shared_bytes = 0;
+    bool file_present = false;
+    struct timespec mtime {};
+    off_t size = 0;
+};
+
+// Caches the sidecar parse per metallib+kernel, revalidated via stat() so an on-disk change is still picked up.
+bool load_inline_static_shared_bytes(const char* metallib_path,
+                                     const char* expected_kernel,
+                                     std::size_t* out_bytes) {
+    if (metallib_path == nullptr || expected_kernel == nullptr || out_bytes == nullptr) {
+        return false;
+    }
+    const std::string sidecar_path = std::string(metallib_path) + ".cumetal-abi";
+    struct stat st {};
+    const bool file_present = ::stat(sidecar_path.c_str(), &st) == 0;
+
+    static std::mutex cache_mutex;
+    static std::unordered_map<std::string, InlineAbiCacheEntry> cache;
+    const std::string cache_key = std::string(metallib_path) + "::" + expected_kernel;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    const auto found = cache.find(cache_key);
+    if (found != cache.end() && found->second.file_present == file_present &&
+        (!file_present ||
+         (found->second.mtime.tv_sec == st.st_mtimespec.tv_sec &&
+          found->second.mtime.tv_nsec == st.st_mtimespec.tv_nsec &&
+          found->second.size == st.st_size))) {
+        *out_bytes = found->second.shared_bytes;
+        return found->second.valid;
+    }
+
+    InlineAbiCacheEntry entry;
+    entry.file_present = file_present;
+    entry.mtime = st.st_mtimespec;
+    entry.size = st.st_size;
+    entry.valid =
+        load_inline_static_shared_bytes_uncached(metallib_path, expected_kernel, &entry.shared_bytes);
+    *out_bytes = entry.shared_bytes;
+    cache[cache_key] = entry;
+    return entry.valid;
 }
 }  // namespace
 


### PR DESCRIPTION
`load_inline_static_shared_bytes()` parsed each kernel's .cumetal-abi sidecar from disk on every call to cudaLaunchKernel's inline descriptor path. This function runs on every launch through that path (cumetal_bench, samples/nativeLaunch, any app using a raw cumetalKernel_t descriptor), so the open+read+parse happened unconditionally per launch - for a small kernel this I/O was comparable to or larger than the actual GPU compute time.

This splits the parser into an uncached `load_inline_static_shared_bytes_uncached()` and a cached wrapper that keys a mutex-guarded unordered_map on metallib_path::kernel_name. Each call still does one stat() to check mtime+size before trusting the cache, so a legitimately-mutated sidecar (an existing test rewrites it mid-run to check malformed-ABI rejection) is still picked up correctly - only the expensive ifstream open/getline/istringstream parse is skipped on a cache hit.

Testing

- Full ctest --exclude-regex '^bench_' suite: same 18 pre-existing failures with and without this change (verified by stashing/rebuilding both ways) - no regressions. functional_runtime_warp_mask_votes_cu, which exercises the sidecar-mutation edge case, passes.
- cumetal_bench A/B (20k launches, vector_add, real sidecar present): wall time per launch dropped from ~0.120ms to ~0.087ms (a ~1.38x speedup, pure CPU-side I/O overhead)