### PR TITLE
Cache the inline-launch ABI sidecar parse (merges #13, with follow-ups)

### DIFF
--- a/runtime/rt/cuda_runtime.cpp
+++ b/runtime/rt/cuda_runtime.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <string_view>
 #include <sstream>
+#include <sys/stat.h>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -55,12 +56,10 @@ void trace_op(const char* tag, const char* detail) {
     std::fflush(stderr);
 }
 
-bool load_inline_static_shared_bytes(const char* metallib_path,
-                                     const char* expected_kernel,
-                                     std::size_t* out_bytes) {
-    if (metallib_path == nullptr || expected_kernel == nullptr || out_bytes == nullptr) {
-        return false;
-    }
+// Uncached parse; callers should go through load_inline_static_shared_bytes below.
+bool load_inline_static_shared_bytes_uncached(const char* metallib_path,
+                                              const char* expected_kernel,
+                                              std::size_t* out_bytes) {
     *out_bytes = 0;
     std::ifstream abi(std::string(metallib_path) + ".cumetal-abi");
     if (!abi) {
@@ -118,6 +117,51 @@ bool load_inline_static_shared_bytes(const char* metallib_path,
         return false;
     }
     return true;
+}
+
+struct InlineAbiCacheEntry {
+    bool valid = false;
+    std::size_t shared_bytes = 0;
+    bool file_present = false;
+    struct timespec mtime {};
+    off_t size = 0;
+};
+
+// Caches the sidecar parse per metallib+kernel, revalidated via stat() so an on-disk change is still picked up.
+bool load_inline_static_shared_bytes(const char* metallib_path,
+                                     const char* expected_kernel,
+                                     std::size_t* out_bytes) {
+    if (metallib_path == nullptr || expected_kernel == nullptr || out_bytes == nullptr) {
+        return false;
+    }
+    const std::string sidecar_path = std::string(metallib_path) + ".cumetal-abi";
+    struct stat st {};
+    const bool file_present = ::stat(sidecar_path.c_str(), &st) == 0;
+
+    static std::mutex cache_mutex;
+    static std::unordered_map<std::string, InlineAbiCacheEntry> cache;
+    const std::string cache_key = std::string(metallib_path) + "::" + expected_kernel;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    const auto found = cache.find(cache_key);
+    if (found != cache.end() && found->second.file_present == file_present &&
+        (!file_present ||
+         (found->second.mtime.tv_sec == st.st_mtimespec.tv_sec &&
+          found->second.mtime.tv_nsec == st.st_mtimespec.tv_nsec &&
+          found->second.size == st.st_size))) {
+        *out_bytes = found->second.shared_bytes;
+        return found->second.valid;
+    }
+
+    InlineAbiCacheEntry entry;
+    entry.file_present = file_present;
+    entry.mtime = st.st_mtimespec;
+    entry.size = st.st_size;
+    entry.valid =
+        load_inline_static_shared_bytes_uncached(metallib_path, expected_kernel, &entry.shared_bytes);
+    *out_bytes = entry.shared_bytes;
+    cache[cache_key] = entry;
+    return entry.valid;
 }
 }  // namespace
 

--- a/runtime/rt/cuda_runtime.cpp
+++ b/runtime/rt/cuda_runtime.cpp
@@ -22,6 +22,7 @@
 #include <dlfcn.h>
 #include <fstream>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <new>
 #include <string>
@@ -31,6 +32,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 struct CUstream_st {};
@@ -127,7 +129,24 @@ struct InlineAbiCacheEntry {
     off_t size = 0;
 };
 
-// Caches the sidecar parse per metallib+kernel, revalidated via stat() so an on-disk change is still picked up.
+inline struct timespec sidecar_mtime(const struct stat& st) {
+#if defined(__APPLE__)
+    return st.st_mtimespec;
+#else
+    return st.st_mtim;
+#endif
+}
+
+// Caches the sidecar parse per (metallib, kernel), revalidated via stat() so an on-disk change is
+// still picked up -- an existing test rewrites a sidecar mid-run and must see the new contents.
+//
+// The revalidation key is (presence, mtime, size). That is exact on APFS, whose timestamps are
+// nanosecond-resolution: two back-to-back rewrites of the same file always land on distinct mtimes,
+// so a same-size in-place edit still invalidates. It would NOT be exact on a volume with coarse
+// (1s/2s) timestamps -- an SMB/NFS mount or a FAT/exFAT disk -- where a same-size rewrite inside one
+// tick would serve a stale shared-byte count, i.e. silently allocate the wrong amount of static
+// threadgroup memory. CuMetal is Apple-Silicon-only and metallibs live in APFS build trees, so this
+// is accepted rather than hashing the contents (which would defeat the point of the cache).
 bool load_inline_static_shared_bytes(const char* metallib_path,
                                      const char* expected_kernel,
                                      std::size_t* out_bytes) {
@@ -137,30 +156,39 @@ bool load_inline_static_shared_bytes(const char* metallib_path,
     const std::string sidecar_path = std::string(metallib_path) + ".cumetal-abi";
     struct stat st {};
     const bool file_present = ::stat(sidecar_path.c_str(), &st) == 0;
+    const struct timespec mtime = sidecar_mtime(st);
 
     static std::mutex cache_mutex;
-    static std::unordered_map<std::string, InlineAbiCacheEntry> cache;
-    const std::string cache_key = std::string(metallib_path) + "::" + expected_kernel;
+    // Keyed on the pair rather than a concatenation: no separator can collide with a path or a
+    // kernel name that happens to contain it.
+    static std::map<std::pair<std::string, std::string>, InlineAbiCacheEntry> cache;
+    const std::pair<std::string, std::string> cache_key(metallib_path, expected_kernel);
 
-    std::lock_guard<std::mutex> lock(cache_mutex);
-    const auto found = cache.find(cache_key);
-    if (found != cache.end() && found->second.file_present == file_present &&
-        (!file_present ||
-         (found->second.mtime.tv_sec == st.st_mtimespec.tv_sec &&
-          found->second.mtime.tv_nsec == st.st_mtimespec.tv_nsec &&
-          found->second.size == st.st_size))) {
-        *out_bytes = found->second.shared_bytes;
-        return found->second.valid;
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex);
+        const auto found = cache.find(cache_key);
+        if (found != cache.end() && found->second.file_present == file_present &&
+            (!file_present ||
+             (found->second.mtime.tv_sec == mtime.tv_sec &&
+              found->second.mtime.tv_nsec == mtime.tv_nsec && found->second.size == st.st_size))) {
+            *out_bytes = found->second.shared_bytes;
+            return found->second.valid;
+        }
     }
 
+    // Parsed outside the lock: a cold miss on one kernel must not serialize launches of every other
+    // kernel. Two threads racing the same miss both parse and store the same result, which is fine.
     InlineAbiCacheEntry entry;
     entry.file_present = file_present;
-    entry.mtime = st.st_mtimespec;
+    entry.mtime = mtime;
     entry.size = st.st_size;
     entry.valid =
         load_inline_static_shared_bytes_uncached(metallib_path, expected_kernel, &entry.shared_bytes);
     *out_bytes = entry.shared_bytes;
-    cache[cache_key] = entry;
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex);
+        cache[cache_key] = entry;
+    }
     return entry.valid;
 }
 }  // namespace

--- a/tests/functional/runtime_warp_mask_votes_test.cpp
+++ b/tests/functional/runtime_warp_mask_votes_test.cpp
@@ -155,6 +155,56 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // The sidecar parse is cached and revalidated on (mtime, size), so the case above -- whose
+    // fixture happens to differ in length from the real sidecar -- only proves the size half of
+    // that check. Rewrite it in place at *identical* byte length and confirm the launch still sees
+    // the new contents; otherwise a stale cache entry would silently allocate the wrong amount of
+    // static threadgroup memory.
+    const cudaError_t restored_status =
+        cudaLaunchKernel(&kernel, dim3(1), dim3(kThreads), args, 0, nullptr);
+    if (restored_status != cudaSuccess) {
+        std::fprintf(stderr,
+                     "FAIL: restored ABI sidecar returned %d, expected cudaSuccess\n",
+                     static_cast<int>(restored_status));
+        return 1;
+    }
+    std::string same_length_corruption = saved_sidecar.str();
+    const std::string kVersionLine = "CUMETAL_ABI_V1";
+    if (same_length_corruption.compare(0, kVersionLine.size(), kVersionLine) != 0) {
+        std::fprintf(stderr, "FAIL: sidecar does not start with %s\n", kVersionLine.c_str());
+        return 1;
+    }
+    same_length_corruption[kVersionLine.size() - 1] = '9';  // CUMETAL_ABI_V1 -> CUMETAL_ABI_V9
+    if (same_length_corruption.size() != saved_sidecar.str().size()) {
+        std::fprintf(stderr, "FAIL: same-length fixture changed the sidecar size\n");
+        return 1;
+    }
+    {
+        std::ofstream corrupted(sidecar_path, std::ios::trunc);
+        corrupted << same_length_corruption;
+        if (!corrupted) {
+            std::fprintf(stderr, "FAIL: unable to write same-length sidecar fixture\n");
+            return 1;
+        }
+    }
+    const cudaError_t same_length_status =
+        cudaLaunchKernel(&kernel, dim3(1), dim3(kThreads), args, 0, nullptr);
+    {
+        std::ofstream restored(sidecar_path, std::ios::trunc);
+        restored << saved_sidecar.str();
+        if (!restored) {
+            std::fprintf(stderr, "FAIL: unable to restore source ABI sidecar\n");
+            return 1;
+        }
+    }
+    if (same_length_status != cudaErrorInvalidValue) {
+        std::fprintf(stderr,
+                     "FAIL: same-length malformed ABI sidecar returned %d, expected "
+                     "cudaErrorInvalidValue (stale sidecar cache?)\n",
+                     static_cast<int>(same_length_status));
+        return 1;
+    }
+
     if (cudaFree(device_output) != cudaSuccess) {
         std::fprintf(stderr, "FAIL: cudaFree\n");
         return 1;


### PR DESCRIPTION
Merges @anudit's #13 (commit preserved with authorship) plus a follow-up commit fixing the residual issues found reviewing it.

## What #13 does

`load_inline_static_shared_bytes()` re-opened and re-parsed each kernel's `.cumetal-abi` sidecar on every launch through `cudaLaunchKernel`'s inline-descriptor path. #13 splits out an uncached parser and caches the result per kernel, revalidating with one `stat()` so an on-disk rewrite is still picked up.

The idea is right and the semantics are preserved exactly, including the subtle parts: a parse that fails *after* reading `shared` still caches the partial byte count next to `valid = false` (same observable behavior, since the caller fails the launch); a missing sidecar caches `file_present = false`, so creating the file later forces a reparse.

## Measured, not claimed

#13's description quotes 0.120 ms → 0.087 ms per launch (~1.38x). I could not reproduce that magnitude. A/B on this branch vs. its parent, Debug, M4 Pro, `cumetal_bench --kernel vector_add --iterations 2000`, `cumetal_wall_ms`:

| config | before | after |
| --- | --- | --- |
| `--elements 1024`, sidecar present | 0.104 ms | 0.091 ms (~1.14x, ~13 µs/launch) |
| `--elements 1024`, **no sidecar** | 0.088 ms | 0.089 ms (unchanged) |
| `--elements 262144`, sidecar present | 0.147 ms | 0.146 ms (noise) |

Two qualifications worth recording:

- **The default `bench_phase5` configuration has no sidecar at all.** `scripts/generate_bench_metallib.sh` runs `bench_kernels.metal` straight through `xcrun` and emits no `.cumetal-abi`, so on the gated bench path this swaps a failed `open()` for a `stat()` — net zero. I had to hand-write a sidecar to see any win. `bench_phase5_all_kernels` and `unit_cumetal_bench_ratio_gate` do not get faster.
- **This is the inline-descriptor branch only.** Registered kernels take the other path and never call it, so llama.cpp, llm.c, and GROMACS are unaffected. The beneficiaries are `cumetal_bench`, `samples/nativeLaunch`, and the ~25 functional tests that launch through a raw `cumetalKernel_t`.

It is still a real CPU-side cost removed on a path we launch millions of times in the test suite, which is why it is worth taking.

## Residual issues, fixed in the follow-up commit

1. **The invalidation contract had no test.** This is the one that mattered. `runtime_warp_mask_votes_test` rewrites the sidecar mid-run, but its malformed fixture happens to differ in *length* from the real one, so it invalidates on size alone — the mtime half of the key was never exercised. I confirmed a cache that ignores mtime entirely still passes the suite unchanged. Added a second mutation that rewrites the sidecar in place at identical byte length (`CUMETAL_ABI_V1` → `CUMETAL_ABI_V9`) and asserts the launch is still rejected. Negative control: dropping mtime from the revalidation condition makes it fail with `same-length malformed ABI sidecar returned 0, expected cudaErrorInvalidValue (stale sidecar cache?)`, so the test measures what it claims to.

2. **Silent-staleness risk on coarse-granularity filesystems, now documented.** `(presence, mtime, size)` is exact on APFS — I measured back-to-back same-size rewrites landing ~90 µs apart, always distinct. It would not be exact on a volume with 1s/2s timestamps (SMB/NFS, FAT/exFAT), where a same-size edit inside one tick serves a stale shared-byte count and silently allocates the wrong amount of static threadgroup memory — the failure class `docs/known-gaps.md` keeps flagging. Accepted rather than hashing contents (which defeats the cache), but the reasoning is now written down at the call site instead of being implicit.

3. **`st_mtimespec` is the Darwin spelling** of `st_mtim`; wrapped so the file does not silently pin itself to macOS without saying so.

4. **The parse ran while holding the cache mutex**, serializing cold-miss launches of unrelated kernels. Moved outside the lock; a raced miss parses twice and stores the same result.

5. **The `path + "::" + kernel` key is ambiguous** for any path or kernel name containing the separator. Keyed on the `(path, kernel)` pair instead, which no separator choice can make collision-free.

## Testing

- `ctest --test-dir build -R '^functional_'` serially: **194/194 pass**, 0 failures (238 s), Debug + shim ON.
- `ctest -R 'warp_mask_votes|inline|abi'`: 25/25.
- Negative control above, to prove the new test is not green-washing.
